### PR TITLE
Add the possibility to apply multiple targets

### DIFF
--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -1,4 +1,3 @@
-# rubocop:disable RescueWithoutErrorClass
 # rubocop:disable Style/SignalException
 ENV['SWIFTLINT_VERSION'] = '0.27.0'
 
@@ -47,7 +46,7 @@ begin
       source_directory: '../../../'
     )
   end
-rescue
+rescue OtherError
   fail('Code coverage creation failed')
 end
 

--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -6,30 +6,30 @@ gitswiftlinter = GitSwiftLinter.new(self)
 gitswiftlinter.lint_files
 
 # Check for warnings
-json_file = 'build/reports/errors.json'
-
-report_files = Dir.glob("build/reports/*.json").select
+report_files = Dir.glob('build/reports/*.json').select
 
 report_files.each do |json_file|
-    if report_files.to_a.count > 1
-      name = File.basename(json_file,File.extname(json_file)).sub("_", " ").split.map(&:capitalize).join(' ')
-      message "#{name}:"
-    end
+  if report_files.to_a.size > 1
+    name = File.basename(json_file, File.extname(json_file)).sub('_', ' ')
+    name = name.split.map(&:capitalize).join(' ')
+    message "#{name}:"
+  end
 
-    xcode_summary.ignored_files = 'Submodules/**'
-    xcode_summary.inline_mode = true
-    xcode_summary.report json_file
-end 
+  xcode_summary.ignored_files = 'Submodules/**'
+  xcode_summary.inline_mode = true
+  xcode_summary.report json_file
+end
 
 # Show Code coverage report
 # Expecting this Dangerfile to be in:
 # `source/Submodules/WeTransfer-iOS-CI/Danger/`
 begin
+  minimum_coverage_percentage = ENV['MINIMUM_COVERAGE_PERCENTAGE'].to_f || 75
   if ENV['WORKSPACE_PATH']
     xcov.report(
       scheme: ENV['SCHEME'],
-      workspace: ENV['WORKSPACE_PATH'], 
-      minimum_coverage_percentage: ENV['MINIMUM_COVERAGE_PERCENTAGE'].to_f || 75,
+      workspace: ENV['WORKSPACE_PATH'],
+      minimum_coverage_percentage: minimum_coverage_percentage,
       include_targets: ENV['XCOV_TARGETS'],
       output_directory: 'xcov_output',
       source_directory: '../../../'
@@ -37,14 +37,14 @@ begin
   else
     xcov.report(
       scheme: ENV['SCHEME'],
-      minimum_coverage_percentage: ENV['MINIMUM_COVERAGE_PERCENTAGE'].to_f || 75,
+      minimum_coverage_percentage: minimum_coverage_percentage,
       include_targets: ENV['XCOV_TARGETS'],
       output_directory: 'xcov_output',
       source_directory: '../../../'
     )
   end
-rescue => error
-  fail("#{error}")
+rescue
+  fail('Code coverage creation failed')
 end
 
 # Run SwiftLint for source code and tests

--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -1,3 +1,5 @@
+# rubocop:disable Lint/RescueWithoutErrorClass
+# rubocop:disable Style/SignalException
 ENV['SWIFTLINT_VERSION'] = '0.27.0'
 
 require File.expand_path('../ext/git_swift_linter.rb', __FILE__)
@@ -9,6 +11,8 @@ gitswiftlinter.lint_files
 report_files = Dir.glob('build/reports/*.json').select
 
 report_files.each do |json_file|
+  next if report_files.to_a.size > 1 && json_file.include?('errors.json')
+
   if report_files.to_a.size > 1
     name = File.basename(json_file, File.extname(json_file)).sub('_', ' ')
     name = name.split.map(&:capitalize).join(' ')

--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -1,4 +1,4 @@
-# rubocop:disable Lint/RescueWithoutErrorClass
+# rubocop:disable RescueWithoutErrorClass
 # rubocop:disable Style/SignalException
 ENV['SWIFTLINT_VERSION'] = '0.27.0'
 

--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -7,22 +7,30 @@ gitswiftlinter.lint_files
 
 # Check for warnings
 json_file = 'build/reports/errors.json'
-if File.file?(json_file)
-  xcode_summary.ignored_files = 'Submodules/**'
-  xcode_summary.inline_mode = true
-  xcode_summary.report 'build/reports/errors.json'
-end
+
+report_files = Dir.glob("build/reports/*.json").select
+
+report_files.each do |json_file|
+    if report_files.to_a.count > 1
+      name = File.basename(json_file,File.extname(json_file)).sub("_", " ").split.map(&:capitalize).join(' ')
+      message "#{name}:"
+    end
+
+    xcode_summary.ignored_files = 'Submodules/**'
+    xcode_summary.inline_mode = true
+    xcode_summary.report json_file
+end 
 
 # Show Code coverage report
 # Expecting this Dangerfile to be in:
 # `source/Submodules/WeTransfer-iOS-CI/Danger/`
 begin
-  if defined?(ENV['WORKSPACE_PATH'])
+  if ENV['WORKSPACE_PATH']
     xcov.report(
       scheme: ENV['SCHEME'],
       workspace: ENV['WORKSPACE_PATH'], 
       minimum_coverage_percentage: ENV['MINIMUM_COVERAGE_PERCENTAGE'].to_f || 75,
-      only_project_targets: true,
+      include_targets: ENV['XCOV_TARGETS'],
       output_directory: 'xcov_output',
       source_directory: '../../../'
     )
@@ -30,13 +38,13 @@ begin
     xcov.report(
       scheme: ENV['SCHEME'],
       minimum_coverage_percentage: ENV['MINIMUM_COVERAGE_PERCENTAGE'].to_f || 75,
-      only_project_targets: true,
+      include_targets: ENV['XCOV_TARGETS'],
       output_directory: 'xcov_output',
       source_directory: '../../../'
     )
   end
-rescue
-  fail('Coverage creation failed')
+rescue => error
+  fail("#{error}")
 end
 
 # Run SwiftLint for source code and tests

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -1,9 +1,12 @@
-desc "Validates the changes with SwiftLint and Danger"
+# rubocop:disable LineLength
+desc 'Validates the changes with SwiftLint and Danger'
 lane :validate_changes do |options|
-  # Set the project name. This will be used in Danger to determine several things like "Are tests updated by detecting files in "PROJECT_NAMETests" folder "
-  ENV["PROJECT_NAME"] = options[:project_name]
-  ENV["SCHEME"] = options[:scheme] || options[:project_name]
-  ENV["SRCROOT"] = "../../../"
+  # Set the project name.
+  # This will be used in Danger to determine several things like:
+  # "Are tests updated by detecting files in "PROJECT_NAMETests" folder "
+  ENV['PROJECT_NAME'] = options[:project_name]
+  ENV['SCHEME'] = options[:scheme] || options[:project_name]
+  ENV['SRCROOT'] = '../../../'
   ENV['XCOV_TARGETS'] = options[:xcov_targets] || "#{options[:project_name]}.framework"
   # Run Danger
   danger(dangerfile: "#{Dir.pwd.gsub(/ /, '\ ')}/../Submodules/WeTransfer-iOS-CI/Danger/Dangerfile")

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -4,6 +4,7 @@ lane :validate_changes do |options|
   ENV["PROJECT_NAME"] = options[:project_name]
   ENV["SCHEME"] = options[:scheme] || options[:project_name]
   ENV["SRCROOT"] = "../../../"
+  ENV['XCOV_TARGETS'] = options[:xcov_targets] || "#{options[:project_name]}.framework"
   # Run Danger
   danger(dangerfile: "#{Dir.pwd.gsub(/ /, '\ ')}/../Submodules/WeTransfer-iOS-CI/Danger/Dangerfile")
 end


### PR DESCRIPTION
We can now create multiple test summaries including coverage reports by passing:

```ruby
validate_changes(project_name: options[:project_name], xcov_targets: "Rabbit.framework, Networking.framework")
```

Also, by running multiple scans and saving reports as separated file names:

```ruby
# Networking Tests
    ENV["XCPRETTY_JSON_FILE_OUTPUT"] = "build/reports/Networking_Tests.json"
    scan(
      scheme: "Networking",
      project: "Vendor/Networking/Networking.xcodeproj",
      device: "iPhone 8",
      clean: true,
      code_coverage: true,
      formatter: "xcpretty-json-formatter"
    )

    # Rabbit Tests
    ENV["XCPRETTY_JSON_FILE_OUTPUT"] = "build/reports/Rabbit_Tests.json"
    scan(
      scheme: options[:project_name],
      project: "#{options[:project_name]}.xcodeproj",
      device: "iPhone 8",
      clean: true,
      code_coverage: true,
      formatter: "xcpretty-json-formatter"
    )
```