### PR TITLE
Make fake data more obviously fake

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,8 @@ def testing_env
     'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true',
     'TRAVIS_PULL_REQUEST' => '800',
     'TRAVIS_REPO_SLUG' => 'WeTransfer/WeTransfer-iOS-CI',
-    'TRAVIS_COMMIT_RANGE' => '759adcbd0d8f...13c4dc8bb61d',
-    'DANGER_GITHUB_API_TOKEN' => '123sbdq54erfsd3422gdfio'
+    'TRAVIS_COMMIT_RANGE' => 'a long complex string',
+    'DANGER_GITHUB_API_TOKEN' => 'your secret github API token'
   }
 end
 


### PR DESCRIPTION
We had some fake data sitting in the spec_helper that was causing false positives when security researchers ran scans. Now it's more obviously fake which will cut down on duplicate reports. 