### PR TITLE
Make messages nicer for multiple project testing

### DIFF
--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -20,7 +20,16 @@ report_files.each do |json_file|
   if report_files.to_a.size > 1
     name = File.basename(json_file, File.extname(json_file)).sub('_', ' ')
     name = name.split.map(&:capitalize).join(' ')
-    message "#{name}:"
+
+    # Put the project name in front of the summary message.
+    json = File.read(json_file)
+    data = JSON.parse(json)
+    data['tests_summary_messages'].each do |message|
+      message.insert(1, ' ' + name + ':') unless message.empty?
+    end
+    File.open(json_file, 'w') do |f|
+      f.puts JSON.pretty_generate(data)
+    end
   end
 
   xcode_summary.ignored_files = 'Submodules/**'


### PR DESCRIPTION
Instead of:

<table>
  <thead>
    <tr>
      <th width="50"></th>
      <th width="100%" data-danger-table="true" data-kind="Message">
          4 Messages
      </th>
     </tr>
  </thead>
  <tbody>
    <tr>
      <td>:book:</td>
      <td data-sticky="false">Coyote Tests:</td>
    </tr>
    <tr>
      <td>:book:</td>
      <td data-sticky="false">Executed 513 tests, with 2 failures (0 unexpected) in 96.910 (97.478) seconds</td>
    </tr>
    <tr>
      <td>:book:</td>
      <td data-sticky="false">Okapi Tests:</td>
    </tr>
    <tr>
      <td>:book:</td>
      <td data-sticky="false">Executed 21 tests, with 0 failures (0 unexpected) in 0.116 (0.134) seconds</td>
    </tr>
  </tbody>
</table>

It will now be:

<table>
  <thead>
    <tr>
      <th width="50"></th>
      <th width="100%" data-danger-table="true" data-kind="Message">
          4 Messages
      </th>
     </tr>
  </thead>
  <tbody>
    <tr>
      <td>:book:</td>
      <td data-sticky="false">Coyote Tests: Executed 513 tests, with 2 failures (0 unexpected) in 96.910 (97.478) seconds</td>
    </tr>
    <tr>
      <td>:book:</td>
      <td data-sticky="false">Okapi Tests: Executed 21 tests, with 0 failures (0 unexpected) in 0.116 (0.134) seconds</td>
    </tr>
  </tbody>
</table>