### PR TITLE
Remove force unwrap checks

### DIFF
--- a/SwiftLint/.swiftlint-source.yml
+++ b/SwiftLint/.swiftlint-source.yml
@@ -1,9 +1,11 @@
 disabled_rules: # Rule identifiers to exclude from running
   - line_length # Documentation can exceed line lengths
   - identifier_name
+  - force_unwrapping
+  - force_cast
+  - force_try
 opt_in_rules:
   - empty_count
-  - force_unwrapping
   - explicit_init
   - first_where
   - object_literal
@@ -13,10 +15,6 @@ opt_in_rules:
   - prohibited_super_call
   - redundant_nil_coalescing
   - switch_case_on_newline
-force_cast: error
-force_try: error
-force_unwrapping: 
-  severity: error
 operator_usage_whitespace: error
 syntactic_sugar: error
 trailing_comma: 

--- a/SwiftLint/.swiftlint-source.yml
+++ b/SwiftLint/.swiftlint-source.yml
@@ -38,11 +38,12 @@ custom_rules:
     included: ".*.swift" # regex that defines paths to include during linting. optional.
     excluded: ".*(Tests|SnapshotHelper|DataTestCase)\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Create your custom wrapper for logging instead of using NSLog, print, or OSLog" # rule name. optional.
-    regex: 'NSLog|import os.log|print\(' # matching pattern
+    regex: 'NSLog|print\(' # matching pattern
     message: "Incorrect logging" # violation message. optional.
     severity: warning # violation severity. optional.
 
 included:
+  - ${SRCROOT}
   - ${SRCROOT}/../Sources
   - ${SRCROOT}/../../Sources
 excluded:
@@ -50,6 +51,7 @@ excluded:
   - ${SRCROOT}/Carthage
   - ${SRCROOT}/Playgrounds
   - ${SRCROOT}/Submodules
+  - ${SRCROOT}/Vendor
   - ${SRCROOT}/Pods
   - ${SRCROOT}/scripts/genstrings.swift
   - ${SRCROOT}/danger/DangerTests.swift


### PR DESCRIPTION
Allowing force unwraps checks. They can be used in some cases and be used as fatalErrors.