### PR TITLE
Only warn for changelog entry if target branch is develop or master

### DIFF
--- a/Danger/ext/git_swift_linter.rb
+++ b/Danger/ext/git_swift_linter.rb
@@ -31,6 +31,13 @@ class GitSwiftLinter
     !files.grep(/.swift/).empty?
   end
 
+  # Whether the changes contain any localization related changes.
+  def pr_contains_localization_changes
+    files = danger_file.git.added_files + danger_file.git.modified_files
+
+    !files.grep(/.strings/).empty?
+  end
+
   # Verify that a changelog edit is included.
   def updated_changelog
     # Sometimes it's a README fix, or something like that - which isn't relevant for
@@ -39,7 +46,8 @@ class GitSwiftLinter
 
     no_changelog_entry = danger_file.git.modified_files.none? { |s| s.casecmp('changelog.md').zero? }
 
-    return if !pr_contains_code_changes || !no_changelog_entry || !not_declared_trivial
+    return if !pr_contains_code_changes && !pr_contains_localization_changes || !no_changelog_entry || !not_declared_trivial
+    return unless %w[master develop].include?(danger_file.git.branch_for_base)
     danger_file.fail('Any changes to code should be reflected in the Changelog. Please consider adding a note there.')
   end
 

--- a/spec/git_swift_linter_spec.rb
+++ b/spec/git_swift_linter_spec.rb
@@ -38,7 +38,19 @@ describe GitSwiftLinter do
     end
 
     it 'Warns if no changelog entry is made while code files are changed' do
+      allow(@gitswiftlinter.danger_file.git).to receive(:branch_for_base).and_return('master')
       allow(@gitswiftlinter.danger_file.git).to receive(:modified_files).and_return(['Coyote/file.swift'])
+      allow(@gitswiftlinter.danger_file.git).to receive(:added_files).and_return([])
+      allow(@gitswiftlinter.danger_file.github).to receive(:pr_title).and_return('PR Title')
+
+      expect(@gitswiftlinter.danger_file).to receive(:fail)
+
+      @gitswiftlinter.updated_changelog
+    end
+
+    it 'Warns if no changelog entry is made while localizable files are changed' do
+      allow(@gitswiftlinter.danger_file.git).to receive(:branch_for_base).and_return('develop')
+      allow(@gitswiftlinter.danger_file.git).to receive(:modified_files).and_return(['Coyote/Localizable.strings'])
       allow(@gitswiftlinter.danger_file.git).to receive(:added_files).and_return([])
       allow(@gitswiftlinter.danger_file.github).to receive(:pr_title).and_return('PR Title')
 
@@ -69,6 +81,17 @@ describe GitSwiftLinter do
 
     it 'Does not warn if a changelog entry is not made and no code files are changed' do
       allow(@gitswiftlinter.danger_file.git).to receive(:modified_files).and_return(['Coyote/travis.yml'])
+      allow(@gitswiftlinter.danger_file.git).to receive(:added_files).and_return([])
+      allow(@gitswiftlinter.danger_file.github).to receive(:pr_title).and_return('PR Title')
+
+      expect(@gitswiftlinter.danger_file).not_to receive(:fail)
+
+      @gitswiftlinter.updated_changelog
+    end
+
+    it 'Does not warn if a changelog entry is not made and target branch is not develop or master' do
+      allow(@gitswiftlinter.danger_file.git).to receive(:branch_for_base).and_return('feature/accounts_syncing')
+      allow(@gitswiftlinter.danger_file.git).to receive(:modified_files).and_return(['Coyote/file.swift'])
       allow(@gitswiftlinter.danger_file.git).to receive(:added_files).and_return([])
       allow(@gitswiftlinter.danger_file.github).to receive(:pr_title).and_return('PR Title')
 


### PR DESCRIPTION
No more need to put #trivial everywhere 🎉 
Also, makes sure a changelog is required for string file changes.

Fixes #31 
Fixes #32 