### PR TITLE
Add a link towards the Bitrise build for quick access

### DIFF
--- a/Danger/Dangerfile
+++ b/Danger/Dangerfile
@@ -10,6 +10,7 @@ gitswiftlinter.lines_of_code
 gitswiftlinter.pr_description
 gitswiftlinter.work_in_progress
 gitswiftlinter.updated_changelog
+gitswiftlinter.show_bitrise_build_url
 
 junit_files = Dir.glob('build/reports/*.xml')
 

--- a/Danger/ext/git_swift_linter.rb
+++ b/Danger/ext/git_swift_linter.rb
@@ -69,6 +69,7 @@ class GitSwiftLinter
   def unowned_usage(file, filelines)
     filelines.each_with_index do |line, index|
       next unless line.include?('unowned self')
+
       danger_file.warn('It is safer to use weak instead of unowned', file: file, line: index + 1)
     end
   end
@@ -77,6 +78,7 @@ class GitSwiftLinter
   def empty_override_methods(file, filelines)
     filelines.each_with_index do |line, index|
       next unless line.include?('override') && line.include?('func') && filelines[index + 1].include?('super') && filelines[index + 2].include?('}') && !filelines[index + 2].include?('{')
+
       danger_file.warn('Override methods which only call super can be removed', file: file, line: index + 3)
     end
   end
@@ -85,7 +87,14 @@ class GitSwiftLinter
   def mark_usage(file, filelines, minimum_lines_count)
     return false if File.basename(file).downcase.include?('test')
     return false if filelines.grep(/MARK:/).any? || filelines.count < minimum_lines_count
+
     danger_file.warn("Consider to place some `MARK:` lines for #{file}, which is over 200 lines big.")
+  end
+
+  # Expose Bitrise buildnumber
+  def show_bitrise_build_url
+    return unless ENV['BITRISE_BUILD_URL']
+    danger_file.message("<a href=\"#{ENV['BITRISE_BUILD_URL']}\">Open the build in Bitrise</a>")
   end
 
   def lint_files

--- a/Danger/ext/git_swift_linter.rb
+++ b/Danger/ext/git_swift_linter.rb
@@ -94,7 +94,8 @@ class GitSwiftLinter
   # Expose Bitrise buildnumber
   def show_bitrise_build_url
     return unless ENV['BITRISE_BUILD_URL']
-    danger_file.message("<a href=\"#{ENV['BITRISE_BUILD_URL']}\">Open the build in Bitrise</a>")
+
+    danger_file.message("View more details on <a href=\"#{ENV['BITRISE_BUILD_URL']}\" target=\"_blank\">Bitrise</a>")
   end
 
   def lint_files

--- a/spec/git_swift_linter_spec.rb
+++ b/spec/git_swift_linter_spec.rb
@@ -237,7 +237,7 @@ describe GitSwiftLinter do
     it 'Prints out the Bitrise build URL if it is set' do
       allow(ENV).to receive(:[]).with('BITRISE_BUILD_URL').and_return('https://www.fakeurl.com')
 
-      expect(@gitswiftlinter.danger_file).to receive(:message).with('<a href="https://www.fakeurl.com">Open the build in Bitrise</a>')
+      expect(@gitswiftlinter.danger_file).to receive(:message).with('View more details on <a href="https://www.fakeurl.com" target="_blank">Bitrise</a>')
 
       @gitswiftlinter.show_bitrise_build_url
     end

--- a/spec/git_swift_linter_spec.rb
+++ b/spec/git_swift_linter_spec.rb
@@ -233,5 +233,19 @@ describe GitSwiftLinter do
 
       @gitswiftlinter.mark_usage('CoyoteTests/fileTests.swift', filelines, 2)
     end
+
+    it 'Prints out the Bitrise build URL if it is set' do
+      allow(ENV).to receive(:[]).with('BITRISE_BUILD_URL').and_return('https://www.fakeurl.com')
+
+      expect(@gitswiftlinter.danger_file).to receive(:message).with('<a href="https://www.fakeurl.com">Open the build in Bitrise</a>')
+
+      @gitswiftlinter.show_bitrise_build_url
+    end
+
+    it 'Does not print out the Bitrise build URL if it is not set' do
+      expect(@gitswiftlinter.danger_file).not_to receive(:message)
+
+      @gitswiftlinter.show_bitrise_build_url
+    end
   end
 end


### PR DESCRIPTION
This adds an HTML Link to the Bitrise build to quickly access the build that has run.
It does not entirely fix the linked issue but linking the logs directly was a bit harder to do.

![image](https://user-images.githubusercontent.com/4329185/71000976-8e44f800-20dc-11ea-8284-35b6e4ba3af7.png)

Fixes #38 