### PR TITLE
Only update the CI submodule remotely

### DIFF
--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -10,11 +10,10 @@ workflows:
     steps:
     - cache-pull: {}
     - script:
-        run_if: [ -d "Submodules/WeTransfer-iOS-CI" ]
         inputs:
         - content: |-
-            # Get the latest master branch for WeTransfer-iOS-CI.
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
+            [ -d "Submodules/WeTransfer-iOS-CI" ] && git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -10,6 +10,7 @@ workflows:
     steps:
     - cache-pull: {}
     - script:
+        run_if: [ -d "Submodules/WeTransfer-iOS-CI" ]
         inputs:
         - content: |-
             # Get the latest master branch for WeTransfer-iOS-CI.

--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -13,7 +13,7 @@ workflows:
         inputs:
         - content: |-
             # Get the latest master branch for WeTransfer-iOS-CI.
-            git submodule update --remote
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -12,8 +12,16 @@ workflows:
     - script:
         inputs:
         - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            if [ ! -d "Submodules/WeTransfer-iOS-CI" ] ; then
+              # file does not exist - simply exit with success
+              exit 0
+            fi
+
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            [ -d "Submodules/WeTransfer-iOS-CI" ] && git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -10,11 +10,10 @@ workflows:
     steps:
     - cache-pull: {}
     - script:
-        run_if: [ -d "Submodules/WeTransfer-iOS-CI" ]
         inputs:
         - content: |-
-            # Get the latest master branch for WeTransfer-iOS-CI.
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
+            [ -d "Submodules/WeTransfer-iOS-CI" ] && git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -10,6 +10,7 @@ workflows:
     steps:
     - cache-pull: {}
     - script:
+        run_if: [ -d "Submodules/WeTransfer-iOS-CI" ]
         inputs:
         - content: |-
             # Get the latest master branch for WeTransfer-iOS-CI.

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -13,7 +13,7 @@ workflows:
         inputs:
         - content: |-
             # Get the latest master branch for WeTransfer-iOS-CI.
-            git submodule update --remote
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -12,8 +12,16 @@ workflows:
     - script:
         inputs:
         - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            if [ ! -d "Submodules/WeTransfer-iOS-CI" ] ; then
+              # file does not exist - simply exit with success
+              exit 0
+            fi
+
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            [ -d "Submodules/WeTransfer-iOS-CI" ] && git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:


### PR DESCRIPTION
Changing the Bitrise.yml to only update the WeTransfer-iOS-CI submodule remotely as well after experiencing issues in Coyote.