### PR TITLE
Merge release 3.1.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 3.1.0
+- Only update the CI submodule remotely ([#57](https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/57)) via @AvdLee
+- Merge release 3.0.0 into master ([#56](https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/56))
+
 ### 3.0.0
 
 - Tag Releasing: automated open-source releases ([#55](https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/55)) via @AvdLee


### PR DESCRIPTION
Containing all the changes for our [**3.1.0 Release**](Warning: Permanently added 'github.com,140.82.114.3' (RSA) to the list of known hosts.
Result of creating the release:

Fetching tags
Latest tag is 3.1.0
Tag 3.1.0 is created at 2020-02-07 14:46:37 +0100
Creating a changelog between tag 3.0.0 and 3.1.0
Tag 3.0.0 is created at 2020-01-28 15:29:20 +0100
Getting all changes since 3.0.0
Creating a release for tag 3.1.0 at repository WeTransfer/WeTransfer-iOS-CI
Marking PR #57 as having been released in version #3.1.0
Marking PR #56 as having been released in version #3.1.0
Successfully posted comment at: https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/57#issuecomment-583404623
Successfully posted comment at: https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/56#issuecomment-583404624
https://github.com/WeTransfer/WeTransfer-iOS-CI/releases/tag/3.1.0
).