### PR TITLE
Only lint files that are changed

### DIFF
--- a/SwiftLint/.swiftlint-tests.yml
+++ b/SwiftLint/.swiftlint-tests.yml
@@ -43,6 +43,7 @@ excluded:
   - ${SRCROOT}/Carthage
   - ${SRCROOT}/.build
   - ${SRCROOT}/Playgrounds
+  - ${SRCROOT}/Vendor
   - ${SRCROOT}/Submodules
   - ${SRCROOT}/scripts/genstrings.swift
   - ${SRCROOT}/danger/DangerTests.swift

--- a/SwiftLint/.swiftlint-tests.yml
+++ b/SwiftLint/.swiftlint-tests.yml
@@ -47,6 +47,7 @@ excluded:
   - ${SRCROOT}/scripts/genstrings.swift
   - ${SRCROOT}/danger/DangerTests.swift
   - ${SRCROOT}/${PROJECT_NAME}
+  - ${SRCROOT}/Shared # Coyote shared folder
   - Example/*/${PROJECT_NAME} # App Store Connect SDK structure
   - ${SRCROOT}/Pods
   - ${SRCROOT}/Sources # Folder for open source projects

--- a/SwiftLint/swiftlint.sh
+++ b/SwiftLint/swiftlint.sh
@@ -1,10 +1,31 @@
+#!/bin/bash
 if [ -z "$CI" ]; then
 	set -e
 	
     if which swiftlint >/dev/null; then
     	BASEDIR=$(dirname "$0")
-        swiftlint --config "$BASEDIR/.swiftlint-source.yml"
-        swiftlint --config "$BASEDIR/.swiftlint-tests.yml" || true # Don't fail if there's no tests to lint
+    	count=0
+
+	    for file_path in $(git ls-files -m --exclude-from=.gitignore | grep ".swift$"); do
+	        export SCRIPT_INPUT_FILE_$count=$file_path
+	        count=$((count + 1))
+	    done
+
+	    for file_path in $(git diff --name-only --cached | grep ".swift$"); do
+	        export SCRIPT_INPUT_FILE_$count=$file_path
+	        count=$((count + 1))
+	    done
+
+		export SCRIPT_INPUT_FILE_COUNT=$count
+
+		if [ "$count" -ne 0 ]; then
+	        echo "Found lintable files! Linting..."
+	        swiftlint lint --use-script-input-files --config "$BASEDIR/.swiftlint-source.yml" --force-exclude;
+		    swiftlint lint --use-script-input-files --config "$BASEDIR/.swiftlint-tests.yml" --force-exclude || true; # Don't fail if there's no tests to lint
+	    else
+	        echo "No files to lint!"
+	        exit 0
+	    fi
     else
     	echo "error: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
     fi

--- a/SwiftLint/swiftlint.sh
+++ b/SwiftLint/swiftlint.sh
@@ -6,24 +6,26 @@ if [ -z "$CI" ]; then
     	BASEDIR=$(dirname "$0")
     	count=0
 
-	    for file_path in $(git ls-files -m --exclude-from=.gitignore | grep ".swift$"); do
-	        export SCRIPT_INPUT_FILE_$count=$file_path
-	        count=$((count + 1))
-	    done
+    	# Unstaged files
+		while read filename; do 
+			export SCRIPT_INPUT_FILE_$count="${filename}"
+			count=$((count + 1))
+		done < <(git diff --relative --name-only $SRCROOT | grep ".swift$")
 
-	    for file_path in $(git diff --name-only --cached | grep ".swift$"); do
-	        export SCRIPT_INPUT_FILE_$count=$file_path
-	        count=$((count + 1))
-	    done
+		# Staged files
+		while read filename; do 
+			export SCRIPT_INPUT_FILE_$count="${filename}"
+			count=$((count + 1))
+		done < <(git diff --relative --diff-filter=d --cached --name-only $SRCROOT | grep ".swift$")
 
 		export SCRIPT_INPUT_FILE_COUNT=$count
 
-		if [ "$count" -ne 0 ]; then
+		if (( $count > 0 )); then
 	        echo "Found lintable files! Linting..."
 	        swiftlint lint --use-script-input-files --config "$BASEDIR/.swiftlint-source.yml" --force-exclude;
 		    swiftlint lint --use-script-input-files --config "$BASEDIR/.swiftlint-tests.yml" --force-exclude || true; # Don't fail if there's no tests to lint
 	    else
-	        echo "No files to lint!"
+	        echo "No files to lint, number of files fount is $count"
 	        exit 0
 	    fi
     else

--- a/SwiftLint/swiftlint.sh
+++ b/SwiftLint/swiftlint.sh
@@ -25,7 +25,7 @@ if [ -z "$CI" ]; then
 	        swiftlint lint --use-script-input-files --config "$BASEDIR/.swiftlint-source.yml" --force-exclude;
 		    swiftlint lint --use-script-input-files --config "$BASEDIR/.swiftlint-tests.yml" --force-exclude || true; # Don't fail if there's no tests to lint
 	    else
-	        echo "No files to lint, number of files fount is $count"
+	        echo "No files to lint, the number of files found is $count"
 	        exit 0
 	    fi
     else


### PR DESCRIPTION
I've been using https://dev.to/jonatanlllima/drops-3-swift-swiftlint-e-swiftformat-1b34 and looked a lot at https://github.com/realm/SwiftLint/issues/413 to see whether we could improve our SwiftLint implementation. Right now, we were linting _all files_ in _all frameworks_ easily adding up ~12 seconds per incremental build. 

In other words, an incremental build in my test case went from 23.4 seconds to 9.9 seconds 🚀 