### PR TITLE
Ignore warnings in SwiftPM

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         title: Force SSH

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         title: Force SSH

--- a/Danger-Swift/Sources/WeTransferPRLinter/XcodeSummaryReporter.swift
+++ b/Danger-Swift/Sources/WeTransferPRLinter/XcodeSummaryReporter.swift
@@ -20,8 +20,14 @@ public enum XcodeSummaryReporter: XcodeSummaryReporting {
         print("Generating Xcode Summary report for \(file.name)")
         let summary = XCodeSummary(filePath: file.path, resultsFilter: { result in
             guard let file = result.file else { return true }
+            
             /// Filter results from submodules
-            return !file.contains("Submodules/") && !result.message.contains("Submodules/")
+            guard !file.contains("Submodules/") && !result.message.contains("Submodules/") else { return false }
+
+            /// Filter results from submodules
+            guard !file.contains("SourcePackages/") && !result.message.contains("SourcePackages/") else { return false }
+
+            return true
         })
         summary.report()
     }


### PR DESCRIPTION
By ignoring the `SourcePackages` folder path we ignore the warnings from SPM.