### PR TITLE
Optimise Bitrise runs

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -51,12 +51,6 @@ workflows:
             # Use the environment FASTLANE_LANE if available. Otherwise, fallback to "test"
             lane=${FASTLANE_LANE:=test}
             bundle exec fastlane $lane
-    - brew-install@0:
-        inputs:
-        - upgrade: 'no'
-        - packages: swiftlint
-        - cache_enabled: 'yes'
-        title: Install SwiftLint
     - script:
         title: Run Danger
         inputs:
@@ -65,7 +59,6 @@ workflows:
             # debug log
             set -x
 
-            #swift build
             bundle exec fastlane unhide_spm_package_dev_dependencies
             swift run danger-swift ci
     - cache-push:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -69,7 +69,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            .build
+            ./build
             ~/.danger-swift
             SourcePackages
 

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -53,6 +53,9 @@ workflows:
             bundle exec fastlane $lane
     - script:
         title: Run Danger
+        deps:
+          brew:
+          - name: swiftlint
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -33,21 +33,19 @@ workflows:
             # git config --global url."git@github.com:".insteadOf "https://github.com/"
             for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
     - script:
-        title: Set GEM_CACHE_PATH env var
+        title: Setup caching for GEMs
         inputs:
         - content: |-
             #!/bin/bash
-            set -ex
-            RBENV_DIR="`cd $(rbenv which ruby)/../..;pwd`"
-            echo "Gem cache directory: $RBENV_DIR"
-            envman add --key GEM_CACHE_PATH --value $RBENV_DIR
+            set -ev
+            envman add --key GEM_HOME --value "$(gem environment gemdir)"
     - bitrise-step-install-bundler: {}
     - script:
         title: Bundle updating
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            bundle update
+            bundle update --path .gem-caches
     - script:
         title: Run Fastlane
         inputs:
@@ -77,5 +75,5 @@ workflows:
             .build
             ~/.danger-swift
             SourcePackages
-
-            $GEM_CACHE_PATH
+            .gem-caches-> ./Gemfile.lock # Invalidate if Gemfile changed
+            $GEM_HOME

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         title: Force SSH

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -41,11 +41,11 @@ workflows:
             envman add --key GEM_HOME --value "$(gem environment gemdir)"
     - bitrise-step-install-bundler: {}
     - script:
-        title: Bundle updating
+        title: Bundle install (with cache)
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            bundle update --path .gem-caches
+            bundle install --path .gem-caches
     - script:
         title: Run Fastlane
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -43,11 +43,16 @@ workflows:
             envman add --key GEM_CACHE_PATH --value $RBENV_DIR
     - bitrise-step-install-bundler: {}
     - script:
-        title: Run Fastlane
+        title: Bundle updating
         inputs:
         - content: |-
             #!/usr/bin/env bash
             bundle update
+    - script:
+        title: Run Fastlane
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
             # Use the environment FASTLANE_LANE if available. Otherwise, fallback to "test"
             lane=${FASTLANE_LANE:=test}
             bundle exec fastlane $lane

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -74,6 +74,5 @@ workflows:
         - cache_paths: |
             $BITRISE_CACHE_DIR
             .build
-            ~/.danger-swift
             .gem-caches
             $GEM_HOME

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -69,7 +69,7 @@ workflows:
         inputs:
         - cache_paths: |
             $BITRISE_CACHE_DIR
-            ./build
+            .build
             ~/.danger-swift
             SourcePackages
 

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         title: Force SSH

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -45,7 +45,8 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            bundle install --path .gem-caches
+            bundle config set --local path '.gem-caches'`
+            bundle install
     - script:
         title: Run Fastlane
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -67,7 +67,7 @@ workflows:
             set -x
 
             bundle exec fastlane unhide_spm_package_dev_dependencies
-            swift run danger-swift ci
+            swift run danger-swift ci --cache-path .build --build-path .build
     - cache-push:
         run_if: true
         inputs:
@@ -75,6 +75,5 @@ workflows:
             $BITRISE_CACHE_DIR
             .build
             ~/.danger-swift
-            SourcePackages
-            .gem-caches-> ./Gemfile.lock # Invalidate if Gemfile changed
+            .gem-caches
             $GEM_HOME

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -45,7 +45,7 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            bundle config set --local path '.gem-caches'`
+            bundle config set --local path '.gem-caches'
             bundle install
     - script:
         title: Run Fastlane

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -40,7 +40,7 @@ lane :test_package do |options|
     # )
 
     destination = 'platform=iOS Simulator,name=iPhone 11'
-    sourcePackagesDir = "#{ENV['PWD']}/SourcePackages"
+    sourcePackagesDir = "#{ENV['PWD']}/.build"
 
     disable_automatic_package_resolution = options.fetch(:disable_automatic_package_resolution, true)
     extra_flags = disable_automatic_package_resolution ? '-disableAutomaticPackageResolution' : ''
@@ -90,7 +90,7 @@ lane :test_project do |options|
       formatter: 'xcpretty-json-formatter',
       result_bundle: true,
       output_directory: 'build/reports/',
-      cloned_source_packages_path: 'SourcePackages'
+      cloned_source_packages_path: '.build'
     )
   rescue StandardError => e
     UI.important("Tests failed for #{e}")


### PR DESCRIPTION
After spending time investigating our current workflow in Bitrise, I've found several ways of how we could improve our pipeline.

- [x] Removed unneeded SwiftLint install (~ 2 minutes)
- [x] Share builds folder between Xcode and Danger for SPM, preventing us from fetching dependencies twice (~2,5 minutes)
- [x] Correctly cache GEMs. This wasn't working before, and now prevents installing GEMs on each run (~ 2 minutes)  