### PR TITLE
Build dev ipa for sending to browser stack

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -279,7 +279,7 @@ lane :appium_build do |options|
     configuration: 'Debug',
     export_method: 'development',
     xcconfig: options[:xcconfig] || ENV['BETA_XCCONFIG'],
-    cloned_source_packages_path: 'SourcePackages'
+    cloned_source_packages_path: '.build'
   )
 
   puts "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -268,7 +268,7 @@ end
 
 desc 'Create a build for running tests on browser stack'
 lane :appium_build do |options|
-
+  scheme = options[:scheme] || ENV['XCODE_SCHEME']
   clear_derived_data
   # Set timeout to prevent xcodebuild -list -project to take to much retries.
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
@@ -283,7 +283,6 @@ lane :appium_build do |options|
   )
 
   puts "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
-  sh "bash ./../Submodules/WeTransfer-iOS-CI/Scripts/test_setup.sh"
 end
 
 desc 'Generates a JWT token used for JWT authorization with the App Store Connect API.'

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -266,6 +266,26 @@ lane :hotfix do
   release(hotfix: true)
 end
 
+desc 'Create a build for running tests on browser stack'
+lane :appium_build do |options|
+
+  clear_derived_data
+  # Set timeout to prevent xcodebuild -list -project to take to much retries.
+  ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
+  ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '120'
+
+  gym(
+    scheme: scheme,
+    configuration: 'Debug',
+    export_method: 'development',
+    xcconfig: options[:xcconfig] || ENV['BETA_XCCONFIG'],
+    cloned_source_packages_path: 'SourcePackages'
+  )
+
+  puts "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
+  sh "bash ./../Submodules/WeTransfer-iOS-CI/Scripts/test_setup.sh"
+end
+
 desc 'Generates a JWT token used for JWT authorization with the App Store Connect API.'
 desc 'The JWT token is added to the shared lane context so that it is automatically loaded into actions that require it.'
 desc ''

--- a/Scripts/test_setup.sh
+++ b/Scripts/test_setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+echo $IPA_OUTPUT_PATH
+output=$(curl -u $BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY \
+-X POST "https://api-cloud.browserstack.com/app-automate/upload" \
+-F "file=@$IPA_OUTPUT_PATH")
+echo 'Curl done'
+echo $output

--- a/Scripts/test_setup.sh
+++ b/Scripts/test_setup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-echo $IPA_OUTPUT_PATH
-output=$(curl -u $BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY \
--X POST "https://api-cloud.browserstack.com/app-automate/upload" \
--F "file=@$IPA_OUTPUT_PATH")
-echo 'Curl done'
-echo $output


### PR DESCRIPTION
To run our tests in BrowserStack devices, should push a dev ipa file to their cloud
This will result in a URL unique to this ipa, that can be consumed later in test frameworks.

The first stage of this PR makes a dev build ready to be uploaded to browserstack 

This lane will later be used in the Bitrise for Appium workflow