### PR TITLE
Disable todo rule in Swiftlint

### DIFF
--- a/SwiftLint/.swiftlint-source.yml
+++ b/SwiftLint/.swiftlint-source.yml
@@ -8,6 +8,7 @@ disabled_rules: # Rule identifiers to exclude from running
   - opening_brace
   - switch_case_alignment
   - trailing_comma
+  - todo
 opt_in_rules:
   - block_based_kvo
   - class_delegate_protocol

--- a/SwiftLint/.swiftlint-tests.yml
+++ b/SwiftLint/.swiftlint-tests.yml
@@ -15,6 +15,7 @@ disabled_rules: # Rule identifiers to exclude from running
   - opening_brace
   - switch_case_alignment
   - trailing_comma
+  - todo
 opt_in_rules:
   - empty_count
   - explicit_init


### PR DESCRIPTION
Since we're only linting changed files, depending on Swiftlint for TODOs is not sufficient. Therefore, we decided to use #warning("TODO: ..") instead, so we will always have a warning visible within Xcode telling us about a TODO.

Though, we need to disable the rule in SwiftLint to prevent duplicate warnings.