### PR TITLE
Run build for testing w/o scan

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         title: Force SSH

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -21,7 +21,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         title: Force SSH

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -14,12 +14,12 @@ lane :test_package do |options|
 
   # test_project(options)
 
-  command = 'xcodebuild'
+  command = "set -o pipefail && cd #{ENV['PWD']} && xcodebuild"
   command += " -scheme #{options[:package_name]}"
   command += " -destination 'platform=iOS Simulator,name=iPhone 13'"
   command += " -derivedDataPath build/derived_data"
   command += " -resultBundlePath 'build/reports/#{options[:package_name]}.xcresult'"
-  command += " -disable-concurrent-testing -enableCodeCoverage YES"
+  command += " -disable-concurrent-destination-testing -enableCodeCoverage YES"
   command += " -clonedSourcePackagesDirPath #{ENV['PWD']}/.build"
   command += " -parallel-testing-enabled NO"
 
@@ -30,6 +30,8 @@ lane :test_package do |options|
   end
 
   sh(command)
+  # [15:22:34]: $ set -o pipefail && cd /Users/vagrant/git && env NSUnbufferedIO=YES xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
+
   # xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
     # xcodebuild -scheme CoreExtensions -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/CoreExtensions.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO test-without-building | tee '/Users/vagrant/git/build/logs/CoreExtensions.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-cr2e2u' 
     # sh("xcodebuild -scheme CredentialStorageHost -project '#{ENV['PWD']}/CredentialStorage/Testing Project/CredentialStorage.xcodeproj' -derivedDataPath build/derived_data -destination 'platform=iOS Simulator,name=iPhone 13' \ -resultBundlePath '#{ENV['PWD']}/build/reports/CredentialStorageHost.xcresult' -disable-concurrent-destination-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO build test")

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -12,7 +12,27 @@ lane :test_package do |options|
   UI.abort_with_message! "Package path is missing" unless options[:package_path]
   UI.abort_with_message! "Package name is missing" unless options[:package_name]
 
-  test_project(options)
+  # test_project(options)
+
+  command = 'xcodebuild'
+  command += " -scheme #{options[:package_name]}"
+  command += " -destination 'platform=iOS Simulator,name=iPhone 13'"
+  command += " -derivedDataPath build/derived_data"
+  command += " -resultBundlePath 'build/reports/#{options[:package_name]}.xcresult'"
+  command += " -disable-concurrent-testing -enableCodeCoverage YES"
+  command += " -clonedSourcePackagesDirPath #{ENV['PWD']}/.build"
+  command += " -parallel-testing-enabled NO"
+
+  if options.fetch(:build_for_testing, false) == true 
+    command += " build-for-testing"
+  elsif options.fetch(:test_without_building, false) == true
+    command += " test-without-building"
+  end
+
+  sh(command)
+  # xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
+    # xcodebuild -scheme CoreExtensions -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/CoreExtensions.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO test-without-building | tee '/Users/vagrant/git/build/logs/CoreExtensions.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-cr2e2u' 
+    # sh("xcodebuild -scheme CredentialStorageHost -project '#{ENV['PWD']}/CredentialStorage/Testing Project/CredentialStorage.xcodeproj' -derivedDataPath build/derived_data -destination 'platform=iOS Simulator,name=iPhone 13' \ -resultBundlePath '#{ENV['PWD']}/build/reports/CredentialStorageHost.xcresult' -disable-concurrent-destination-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO build test")
 end
 
 desc 'Runs tests for an external project'

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -31,11 +31,6 @@ lane :test_package do |options|
     end
 
     sh(command)
-    # [15:22:34]: $ set -o pipefail && cd /Users/vagrant/git && env NSUnbufferedIO=YES xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
-
-      # xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
-      # xcodebuild -scheme CoreExtensions -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/CoreExtensions.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO test-without-building | tee '/Users/vagrant/git/build/logs/CoreExtensions.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-cr2e2u' 
-      # sh("xcodebuild -scheme CredentialStorageHost -project '#{ENV['PWD']}/CredentialStorage/Testing Project/CredentialStorage.xcodeproj' -derivedDataPath build/derived_data -destination 'platform=iOS Simulator,name=iPhone 13' \ -resultBundlePath '#{ENV['PWD']}/build/reports/CredentialStorageHost.xcresult' -disable-concurrent-destination-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO build test")
   end
 end
 

--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -12,29 +12,31 @@ lane :test_package do |options|
   UI.abort_with_message! "Package path is missing" unless options[:package_path]
   UI.abort_with_message! "Package name is missing" unless options[:package_name]
 
-  # test_project(options)
+  if options.fetch(:build_for_testing, false) == false 
+    test_project(options)
+  else 
+    command = "set -o pipefail && cd #{ENV['PWD']} && xcodebuild"
+    command += " -scheme #{options[:package_name]}"
+    command += " -destination 'platform=iOS Simulator,name=iPhone 13'"
+    command += " -derivedDataPath build/derived_data"
+    command += " -resultBundlePath 'build/reports/#{options[:package_name]}.xcresult'"
+    command += " -disable-concurrent-destination-testing -enableCodeCoverage YES"
+    command += " -clonedSourcePackagesDirPath #{ENV['PWD']}/.build"
+    command += " -parallel-testing-enabled NO"
 
-  command = "set -o pipefail && cd #{ENV['PWD']} && xcodebuild"
-  command += " -scheme #{options[:package_name]}"
-  command += " -destination 'platform=iOS Simulator,name=iPhone 13'"
-  command += " -derivedDataPath build/derived_data"
-  command += " -resultBundlePath 'build/reports/#{options[:package_name]}.xcresult'"
-  command += " -disable-concurrent-destination-testing -enableCodeCoverage YES"
-  command += " -clonedSourcePackagesDirPath #{ENV['PWD']}/.build"
-  command += " -parallel-testing-enabled NO"
+    if options.fetch(:build_for_testing, false) == true 
+      command += " build-for-testing"
+    elsif options.fetch(:test_without_building, false) == true
+      command += " test-without-building"
+    end
 
-  if options.fetch(:build_for_testing, false) == true 
-    command += " build-for-testing"
-  elsif options.fetch(:test_without_building, false) == true
-    command += " test-without-building"
+    sh(command)
+    # [15:22:34]: $ set -o pipefail && cd /Users/vagrant/git && env NSUnbufferedIO=YES xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
+
+      # xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
+      # xcodebuild -scheme CoreExtensions -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/CoreExtensions.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO test-without-building | tee '/Users/vagrant/git/build/logs/CoreExtensions.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-cr2e2u' 
+      # sh("xcodebuild -scheme CredentialStorageHost -project '#{ENV['PWD']}/CredentialStorage/Testing Project/CredentialStorage.xcodeproj' -derivedDataPath build/derived_data -destination 'platform=iOS Simulator,name=iPhone 13' \ -resultBundlePath '#{ENV['PWD']}/build/reports/CredentialStorageHost.xcresult' -disable-concurrent-destination-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO build test")
   end
-
-  sh(command)
-  # [15:22:34]: $ set -o pipefail && cd /Users/vagrant/git && env NSUnbufferedIO=YES xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
-
-  # xcodebuild -scheme WeTransfer-iOS-SDK-Package -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/WeTransfer-iOS-SDK-Package.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO build-for-testing | tee '/Users/vagrant/git/build/logs/WeTransfer-iOS-SDK-Package.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-14zno4m' 
-    # xcodebuild -scheme CoreExtensions -destination 'platform=iOS Simulator,id=F5810D22-FE42-4ACE-A3EA-F7592F3EE45F' -derivedDataPath build/derived_data -resultBundlePath 'build/reports/CoreExtensions.xcresult' -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.build -parallel-testing-enabled NO test-without-building | tee '/Users/vagrant/git/build/logs/CoreExtensions.log' | xcpretty  --report junit --output '/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/junit_report20211028-1766-cr2e2u' 
-    # sh("xcodebuild -scheme CredentialStorageHost -project '#{ENV['PWD']}/CredentialStorage/Testing Project/CredentialStorage.xcodeproj' -derivedDataPath build/derived_data -destination 'platform=iOS Simulator,name=iPhone 13' \ -resultBundlePath '#{ENV['PWD']}/build/reports/CredentialStorageHost.xcresult' -disable-concurrent-destination-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO build test")
 end
 
 desc 'Runs tests for an external project'


### PR DESCRIPTION
It turned out that the `build-for-testing` script runs faster when executed manually. The other testing projects were slower when using `xcodebuild` directly, so lets use it only for build for testing.