### PR TITLE
Retry tests on failure

### DIFF
--- a/Fastlane/Fastfile
+++ b/Fastlane/Fastfile
@@ -68,7 +68,7 @@ lane :test_project do |options|
       skip_slack: true,
       output_types: '',
       prelaunch_simulator: true,
-      xcargs: "-clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO",
+      xcargs: "-clonedSourcePackagesDirPath #{sourcePackagesDir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3",
       include_simulator_logs: false, # Needed for this: https://github.com/fastlane/fastlane/issues/8909
       result_bundle: true,
       output_directory: 'build/reports/',


### PR DESCRIPTION
New in Xcode 13 is the option to retry a test on failure. This can be a great way to reduce the number of flaky tests.

Fixes #96 