### PR TITLE
Update PATH to correct location

### DIFF
--- a/BuildTools/swiftformat.sh
+++ b/BuildTools/swiftformat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ $(uname -p) == 'arm' ]]; then
-    export PATH=/usr/local/bin:$PATH
+    export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
 fi
 
 if [ -z "$CI" ]; then

--- a/BuildTools/swiftformat.sh
+++ b/BuildTools/swiftformat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ $(uname -p) == 'arm' ]]; then
-    export PATH="$PATH:/opt/homebrew/bin"
+    export PATH=/usr/local/bin:$PATH
 fi
 
 if [ -z "$CI" ]; then

--- a/BuildTools/swiftlint.sh
+++ b/BuildTools/swiftlint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ $(uname -p) == 'arm' ]]; then
-    export PATH="$PATH:/opt/homebrew/bin"
+    export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
 fi
 
 if [ -z "$CI" ]; then


### PR DESCRIPTION
The precommit hook failed. Exporting the PATH was indeed the fix, but to a different location.

This was caused due to the fact that I had `mint` installed on my previous non-M1 Mac, which installed the brew packages to a different directory than it would with a fresh install. More context [here](https://apple.stackexchange.com/questions/410825/apple-silicon-port-all-homebrew-packages-under-usr-local-opt-to-opt-homebrew)

Therefore, we're now both supporting `/opt/homebrew/bin` (new) and `/usr/local/bin` (old)

![image (10)](https://user-images.githubusercontent.com/4329185/141098513-312880a5-a2cc-4500-bcbc-ee077f7e5d2b.png)