### PR TITLE
[Danger] Report skipped tests

### DIFF
--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
@@ -35,8 +35,8 @@ final class XCResultSummartReporterTests: XCTestCase {
         WeTransferPRLinter.lint(using: danger, swiftLintExecutor: MockedSwiftLintExecutor.self, reportsPath: buildFolder.path, fileManager: stubbedFileManager, environmentVariables: [:])
 
         XCTAssertEqual(danger.messages.map(\.message), [
-            "TestUITests: Executed 1 tests, with 0 failures and 0 retried tests in 16.058 seconds",
-            "TestThisDude: Executed 6 tests, with 2 failures and 0 retried tests in 0.534 seconds"
+            "TestUITests: Executed 1 tests (0 failed, 0 retried, 0 skipped) in 16.058 seconds",
+            "TestThisDude: Executed 6 tests (2 failed, 0 retried, 0 skipped) in 0.534 seconds"
         ])
 
         XCTAssertEqual(danger.warnings.count, 1)
@@ -67,12 +67,13 @@ final class XCResultSummartReporterTests: XCTestCase {
         WeTransferPRLinter.lint(using: danger, swiftLintExecutor: MockedSwiftLintExecutor.self, reportsPath: buildFolder.path, fileManager: stubbedFileManager, environmentVariables: [:])
 
         XCTAssertEqual(danger.messages.map(\.message), [
-            "PRLinterAppTests: Executed 10 tests, with 1 failures and 1 retried tests in 0.097 seconds"
+            "PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds"
         ], "It should only report the actual failed test, instead of also the retried succeeded one")
 
-        XCTAssertEqual(danger.warnings.count, 1)
+        XCTAssertEqual(danger.warnings.count, 2)
         XCTAssertEqual(danger.warnings.map(\.message), [
-            "**PRLinterViewModelTests.testFlaky() succeeded after retry:**<br/>XCTAssertTrue failed"
+            "**PRLinterViewModelTests.testFlaky() succeeded after retry:**<br/>XCTAssertTrue failed",
+            "**PRLinterViewModelTests/testSkippedExample():**<br/>PRLinterAppTests.swift:32 Test skipped - This test should be skipped"
         ], "It should report a retried test including the retry count")
 
         XCTAssertEqual(danger.fails.count, 1)
@@ -98,8 +99,8 @@ final class XCResultSummartReporterTests: XCTestCase {
         WeTransferPRLinter.lint(using: danger, swiftLintExecutor: MockedSwiftLintExecutor.self, reportsPath: buildFolder.path, fileManager: stubbedFileManager, environmentVariables: [:])
 
         XCTAssertEqual(danger.messages.map(\.message), [
-            "PRLinterAppTests: Executed 10 tests, with 1 failures and 1 retried tests in 0.097 seconds",
-            "PRLinterAppTests: Executed 10 tests, with 1 failures and 1 retried tests in 0.097 seconds"
+            "PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds",
+            "PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds"
         ], "Both reports should be handled")
 
         XCTAssertEqual(danger.markdowns.count, 1, "Coverage reports should be combined")


### PR DESCRIPTION
Since we're going to use skipping tests for flaky/failing tests, we should report these into Danger as well.

Example:
`**PRLinterViewModelTests/testSkippedExample():**<br/>PRLinterAppTests.swift:32 Test skipped - This test should be skipped`

And summary:
`PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds`

Fixes #107 