### PR TITLE
Add `${SRCROOT}/*/Tests` to excluded paths in `swiftlint-source.yml`

### DIFF
--- a/BuildTools/.swiftlint-source.yml
+++ b/BuildTools/.swiftlint-source.yml
@@ -90,3 +90,4 @@ excluded:
   - ${SRCROOT}/.rbenv
   - ${SRCROOT}/*/*/*/*/main.swift # App Store Connect SDK structure
   - ${SRCROOT}/*/*/Tests # App Store Connect SDK structure
+  - ${SRCROOT}/*/*/*/*/PackageJSON.swift

--- a/BuildTools/.swiftlint-source.yml
+++ b/BuildTools/.swiftlint-source.yml
@@ -84,10 +84,10 @@ excluded:
   - ${SRCROOT}/bundle
   - ${SRCROOT}/scripts/genstrings.swift
   - ${SRCROOT}/danger/DangerTests.swift
-  - ${SRCROOT}/*Tests
   - ${SRCROOT}/*UITests
   - ${SRCROOT}/Tests
+  - ${SRCROOT}/*Tests
+  - ${SRCROOT}/*/Tests
   - ${SRCROOT}/.rbenv
   - ${SRCROOT}/*/*/*/*/main.swift # App Store Connect SDK structure
   - ${SRCROOT}/*/*/Tests # App Store Connect SDK structure
-  - ${SRCROOT}/*/Tests

--- a/BuildTools/.swiftlint-source.yml
+++ b/BuildTools/.swiftlint-source.yml
@@ -90,4 +90,4 @@ excluded:
   - ${SRCROOT}/.rbenv
   - ${SRCROOT}/*/*/*/*/main.swift # App Store Connect SDK structure
   - ${SRCROOT}/*/*/Tests # App Store Connect SDK structure
-  - ${SRCROOT}/*/*/*/*/PackageJSON.swift
+  - ${SRCROOT}/*/Tests


### PR DESCRIPTION
It was causing some test file within the SDK's `SPMDependencyResolver` tests to trigger a long file warning, specifically PackageJSON.swift which is auto generated it seems. 