### PR TITLE
Always export path for ARM

### DIFF
--- a/BuildTools/swiftformat.sh
+++ b/BuildTools/swiftformat.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [[ $(uname -p) == 'arm' ]]; then
-    export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
-fi
+export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
 
 if [ -z "$CI" ]; then
     BASEDIR=$(dirname "$0")


### PR DESCRIPTION
Since we're all on ARM macs either way. This solves an issue I had with SourceTree in relationship to precommit hooks:

![](https://files.slack.com/files-pri/T02PT9855-F02QPESU0E7/image.png)

