### PR TITLE
Skip running CI for draft PRs

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -14,7 +14,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             if [ "$GITHUB_PR_IS_DRAFT" = true ] ; then
-                echo 'Cancelling run since the PR is in draft'
+                echo 'Cancelling CI run since the PR is in draft'
                 exit 1
             fi
     - cache-pull: {}

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -14,7 +14,8 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             if [ "$GITHUB_PR_IS_DRAFT" = true ] ; then
-            exit 0
+                echo 'Cancelling run since the PR is in draft'
+                exit 1
             fi
     - cache-pull: {}
     - script:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -8,6 +8,14 @@ trigger_map:
 workflows:
   wetransfer_pr_testing:
     steps:
+    - script@1:
+        title: Skip running for Draft PRs
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            if [ "$GITHUB_PR_IS_DRAFT" = true ] ; then
+            exit 0
+            fi
     - cache-pull: {}
     - script:
         run_if: .IsCI


### PR DESCRIPTION
Draft PRs are likely to receive updates, which means that the CI run is not valuable. In other words; you'll do a new CI run either way, so it's better to skip CI right away and save build credits.

The status check will fail right away. There's currently no other way of doing this, as it would've been ideal to not even run Bitrise for draft PRs. Though, for the time being, this will be a good solution. More context on the Bitrise blog: https://blog.bitrise.io/post/skip-certain-builds-or-only-some-steps-with-the-draft-pr-env-var

Also, if you've been using draft PRs to get early CI results, it's likely better to just run Bitrise locally or run tests locally.

Fixes #118 