### PR TITLE
Delete pre-release tags after a successful release

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -258,6 +258,11 @@ lane :release do |options|
       }
     )
 
+    # Delete 1 pre-release found before the release we just created.
+    # This is temporarily set to 1 to test out. We can eventually increase this number slowly
+    # so we will eventually clean up all pre-releases.
+    sh("gitbuddy tagDeletion -u #{tag_name} -l 1 --prerelease-only --verbose")
+
     # Currently doesn't work because as you can't download dsyms with an API key
     # upload_dsyms
 


### PR DESCRIPTION
Once https://github.com/WeTransfer/GitBuddy/pull/74 is merged, we can delete GitHub releases and matching tags using GitBuddy.

This PR configures the command and deletes 1 pre-release per time, so we can test out the logic in production. I've already tested the logic locally, both through the terminal and unit tests. Yet, I want to slowly enable this to prevent us from deleting tags unexpectedly.

This is also the last part of #86.

Fixes #86 