### PR TITLE
Add extra note about a released build

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -223,6 +223,11 @@ lane :release do |options|
     # Refresh key as it's only valid for 20 minutes and TestFlight can take a long time.
     authenticate(use_app_manager_role: true)
 
+    stripped_changelog.prepend("This build has been submitted to the App Store.\n\n")
+    testflight_groups = options[:groups] || ENV['TESTFLIGHT_GROUPS_RELEASE']
+
+    puts "Creating a TestFlight build which will be available to these groups: #{testflight_groups}"
+
     testflight(
       beta_app_review_info: {
         contact_email: options[:contact_email] || ENV['BETA_CONTACT_EMAIL'],
@@ -234,7 +239,7 @@ lane :release do |options|
       },
       skip_waiting_for_build_processing: false,
       skip_submission: true,
-      groups: options[:groups] || ENV['TESTFLIGHT_GROUPS_RELEASE'],
+      groups: testflight_groups,
       changelog: stripped_changelog,
       team_id: options[:team_id] || ENV['FASTLANE_ITC_TEAM_ID'],
       verbose: true


### PR DESCRIPTION
Our setup should've already been correct for releasing the submitted builds to QA. Yet, it didn't work, so I added some extra logging so we can hopefully find out later.

I've also added an extra note to the changelog to make it clearer for QA that a build was submitted.

Fixes #125 