### PR TITLE
Improve Mint packages installation

### DIFF
--- a/BuildTools/swiftformat.sh
+++ b/BuildTools/swiftformat.sh
@@ -2,6 +2,16 @@
 
 if [ -z "$CI" ]; then
     export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+
     BASEDIR=$(dirname "$0")
-    xcrun --sdk macosx mint run -m "$BASEDIR/Mintfile" SwiftFormat --config "$BASEDIR/.swiftformat" .
+    MINT_FILE_PATH=$BASEDIR/Mintfile
+    SWIFT_FORMAT=SwiftFormat
+
+    SWIFT_FORMAT_VERSION=$(grep -F $SWIFT_FORMAT $MINT_FILE_PATH)
+
+    if ! xcrun --sdk macosx mint which -s $SWIFT_FORMAT_VERSION > /dev/null; then
+      xcrun --sdk macosx mint bootstrap -m $MINT_FILE_PATH
+    fi
+
+    xcrun --sdk macosx mint run -m $MINT_FILE_PATH $SWIFT_FORMAT --config "$BASEDIR/.swiftformat" .
 fi

--- a/BuildTools/swiftlint.sh
+++ b/BuildTools/swiftlint.sh
@@ -6,6 +6,15 @@ if [ -z "$CI" ]; then
     set -e
 
     BASEDIR=$(dirname "$0") # Sets the folder to WeTransfer-iOS-CI/BuildTools/
+
+    MINT_FILE_PATH=$BASEDIR/Mintfile
+    SWIFT_LINT=SwiftLint
+    SWIFT_LINT_VERSION=$(grep -F $SWIFT_LINT $MINT_FILE_PATH)
+
+    if ! xcrun --sdk macosx mint which -s $SWIFT_LINT_VERSION > /dev/null; then
+      xcrun --sdk macosx mint bootstrap -m $MINT_FILE_PATH
+    fi
+
     execution_directory="$(pwd)"
     count=0
     export SRCROOT="$(pwd)"
@@ -13,21 +22,21 @@ if [ -z "$CI" ]; then
     printf "\nExecuting SwiftLint from ${execution_directory}\n"
 
     # Unstaged files
-    while read filename; do 
+    while read filename; do
         export SCRIPT_INPUT_FILE_$count="${filename}"
         echo "Found '${filename}'"
         count=$((count + 1))
     done < <(git diff --relative --name-only $SRCROOT | grep ".swift$")
 
     # Staged files
-    while read filename; do 
+    while read filename; do
         export SCRIPT_INPUT_FILE_$count="${filename}"
         echo "Found '${filename}'"
         count=$((count + 1))
     done < <(git diff --relative --diff-filter=d --cached --name-only $SRCROOT | grep ".swift$")
 
     # Committed files
-    while read filename; do 
+    while read filename; do
         export SCRIPT_INPUT_FILE_$count="${filename}"
         echo "Found '${filename}'"
         count=$((count + 1))
@@ -37,7 +46,7 @@ if [ -z "$CI" ]; then
 
     if (( $count > 0 )); then
         echo "Found ${count} lintable files! Linting..."
-        xcrun --sdk macosx mint run -m "$BASEDIR/Mintfile" SwiftLint lint --use-script-input-files --config "$BASEDIR/.swiftlint.yml" --force-exclude || true;
+        xcrun --sdk macosx mint run -m $MINT_FILE_PATH $SWIFT_LINT lint --use-script-input-files --config "$BASEDIR/.swiftlint.yml" --force-exclude || true;
     else
         echo "No files to lint, the number of files found is $count"
         exit 0


### PR DESCRIPTION
This PR improves the Mint packages installation in case they are not installed. This will be of help when the packages are updated, but the bootstrap wasn't run manually.

In case one of the packages are not installed, we're going to run `mint bootstrap` to have them installed.