### PR TITLE
Fix beta build delivery

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -57,9 +57,10 @@ lane :beta do |options|
     # Refresh key as it's only valid for 20 minutes and gym can take a long time.
     authenticate(use_app_manager_role: true)
 
+    # Get the name of the current git branch.
     branch_name = ENV['BITRISE_GIT_BRANCH']
-    if branch_name?
-      branch_name = "develop"
+    if branch_name.nil? || branch_name.empty?
+      branch_name = git_branch
     end
 
     # Create a new GitHub release

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -57,6 +57,11 @@ lane :beta do |options|
     # Refresh key as it's only valid for 20 minutes and gym can take a long time.
     authenticate(use_app_manager_role: true)
 
+    branch_name = ENV['BITRISE_GIT_BRANCH']
+    if branch_name?
+      branch_name = "develop"
+    end
+
     # Create a new GitHub release
     last_non_candidate_tag = latest_github_non_candidate_tag
     release_title = "#{tag_name} - App Store Release Candidate"


### PR DESCRIPTION
Fixes a mistake where we were using branch name while it was not defined yet.

We'll now first check if we can use the Bitrise branch name and fall back to develop if the environment doesn't contain this variable.