### PR TITLE
Deliver `xcresult` file as build artifact

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -36,7 +36,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -36,7 +36,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI
@@ -80,6 +80,13 @@ workflows:
                 cd Submodules/WeTransfer-iOS-CI
                 swift run danger-swift ci --cache-path ../../.build --build-path ../../.build --cwd ../../
             fi
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - notify_user_groups: none
+        - is_enable_public_page: 'false'
+        - is_compress: 'true'
+        - debug_mode: 'true'
+        - deploy_path: build/reports/
     - cache-push:
         run_if: true
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -86,7 +86,7 @@ workflows:
         - is_enable_public_page: 'false'
         - is_compress: 'true'
         - debug_mode: 'true'
-        - deploy_path: build/reports/
+        - deploy_path: build/
     - cache-push:
         run_if: true
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -81,12 +81,13 @@ workflows:
                 swift run danger-swift ci --cache-path ../../.build --build-path ../../.build --cwd ../../
             fi
     - deploy-to-bitrise-io@2:
+        is_skippable: true
         inputs:
         - notify_user_groups: none
         - is_enable_public_page: 'false'
         - is_compress: 'true'
         - debug_mode: 'true'
-        - deploy_path: build/
+        - deploy_path: build/reports/
     - cache-push:
         run_if: true
         inputs:

--- a/BuildTools/Mintfile
+++ b/BuildTools/Mintfile
@@ -1,2 +1,2 @@
-nicklockwood/SwiftFormat@0.49.6
-realm/SwiftLint@0.47.0
+nicklockwood/SwiftFormat
+realm/SwiftLint

--- a/BuildTools/Mintfile
+++ b/BuildTools/Mintfile
@@ -1,2 +1,2 @@
-nicklockwood/SwiftFormat
-realm/SwiftLint
+nicklockwood/SwiftFormat@0.49.7
+realm/SwiftLint@0.47.0


### PR DESCRIPTION
The workflow is changed to now deliver the `xcresult` file as build artifact. If the `xcresult` file doesn't exist, the step will silently fail since it's marked as `skippable`. I decided to only upload the `xcresult` file to keep our CI runs as performant as possible.

I've also removed the version lock on SwiftFormat and SwiftLint since my commits were constantly trying to downgrade my local installed SwiftFormat. I also think it's better to keep them up to date with latest version. Let me know if you disagree!