### PR TITLE
Disable file and line reporting to fix Danger warning and error reports

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "danger-swift",
+        "repositoryURL": "https://github.com/danger/swift",
+        "state": {
+          "branch": null,
+          "revision": "c1bba33f705ca0fd4a0022997c8b696210083755",
+          "version": "3.12.3"
+        }
+      },
+      {
         "package": "Version",
         "repositoryURL": "https://github.com/mxcl/Version",
         "state": {

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -74,11 +74,13 @@ public enum WeTransferPRLinter {
                     guard file.contains(pathToFilter) else {
                         continue
                     }
+                    print("Filtered out \(file) for filtered path \(pathToFilter)")
                     return false
                 }
 
                 return true
             }
+            print("Finished reporting XCResult summaries.")
         } catch let error as LocationError where error.isMissingError {
             danger.message("No tests found for the current changes in \(reportsPath)")
         } catch {

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/Extensions/Danger+XCResultItemReporting.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/Extensions/Danger+XCResultItemReporting.swift
@@ -8,11 +8,11 @@ extension DangerDSL {
         if let file = resultItem.file, let line = resultItem.line {
             switch resultItem.category {
             case .message:
-                message(message: resultItem.message, file: file, line: line)
+                message(message: resultItem.message)
             case .error:
-                fail(message: resultItem.message, file: file, line: line)
+                fail(message: resultItem.message)
             case .warning:
-                warn(message: resultItem.message, file: file, line: line)
+                warn(message: resultItem.message)
             }
         } else {
             switch resultItem.category {

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/Extensions/Danger+XCResultItemReporting.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/Extensions/Danger+XCResultItemReporting.swift
@@ -5,14 +5,14 @@ extension DangerDSL {
     /// Reports the given result item based on the available metadata like file and line number.
     /// - Parameter resultItem: The result item to report to Danger.
     func report(_ resultItem: XCResultItem) {
-        if let file = resultItem.file, let line = resultItem.line {
+        if let _ = resultItem.file, let _ = resultItem.line {
             switch resultItem.category {
             case .message:
-                message(message: resultItem.message)
+                message(resultItem.message)
             case .error:
-                fail(message: resultItem.message)
+                fail(resultItem.message)
             case .warning:
-                warn(message: resultItem.message)
+                warn(resultItem.message)
             }
         } else {
             switch resultItem.category {

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/IssueSummaries.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/IssueSummaries.swift
@@ -63,20 +63,20 @@ extension ActionTestSummary: XCResultItemsConvertible {
 extension TestFailureIssueSummary {
     func createTestFailureResult(context: ResultGenerationContext, testPlanRunSummaries: ActionTestPlanRunSummaries) -> [XCResultItem] {
         let message = "**\(testCaseName):**<br/>\(message)"
-        let fileMetadata = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
+        let _ = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
         return [XCResultItem(message: message, category: .error)]
     }
 
     func createTestRetriedResult(context: ResultGenerationContext, testPlanRunSummaries: ActionTestPlanRunSummaries) -> [XCResultItem] {
         let message = "**\(testCaseName) succeeded after retry:**<br/>\(message)"
-        let fileMetadata = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
+        let _ = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
         return [XCResultItem(message: message, category: .warning)]
     }
 }
 
 extension IssueSummary {
     func createResults(category: XCResultItem.Category, context: ResultGenerationContext) -> [XCResultItem] {
-        let fileMetadata = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
+        let _ = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
         return [XCResultItem(message: message, category: category)]
     }
 }

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/IssueSummaries.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/IssueSummaries.swift
@@ -64,20 +64,20 @@ extension TestFailureIssueSummary {
     func createTestFailureResult(context: ResultGenerationContext, testPlanRunSummaries: ActionTestPlanRunSummaries) -> [XCResultItem] {
         let message = "**\(testCaseName):**<br/>\(message)"
         let fileMetadata = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
-        return [XCResultItem(message: message, file: fileMetadata?.filename, line: fileMetadata?.line, category: .error)]
+        return [XCResultItem(message: message, category: .error)]
     }
 
     func createTestRetriedResult(context: ResultGenerationContext, testPlanRunSummaries: ActionTestPlanRunSummaries) -> [XCResultItem] {
         let message = "**\(testCaseName) succeeded after retry:**<br/>\(message)"
         let fileMetadata = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
-        return [XCResultItem(message: message, file: fileMetadata?.filename, line: fileMetadata?.line, category: .warning)]
+        return [XCResultItem(message: message, category: .warning)]
     }
 }
 
 extension IssueSummary {
     func createResults(category: XCResultItem.Category, context: ResultGenerationContext) -> [XCResultItem] {
         let fileMetadata = documentLocationInCreatingWorkspace?.fileMetadata(fileManager: context.fileManager)
-        return [XCResultItem(message: message, file: fileMetadata?.filename, line: fileMetadata?.line, category: category)]
+        return [XCResultItem(message: message, category: category)]
     }
 }
 

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
@@ -50,8 +50,10 @@ final class XCResultSummartReporterTests: XCTestCase {
         XCTAssertEqual(danger.fails.count, 2)
         let failure = try XCTUnwrap(danger.fails.first)
         XCTAssertEqual(failure.message, "**TestTests.testFailureJosh1():**<br/>XCTAssertTrue failed")
-        XCTAssertEqual(failure.file, "test-ios/TestTests/TestTests.swift")
-        XCTAssertEqual(failure.line, 36)
+
+        // Enable once inline reporting works again.
+        // XCTAssertEqual(failure.file, "test-ios/TestTests/TestTests.swift")
+        // XCTAssertEqual(failure.line, 36)
     }
 
     func testNotReportingRetriedSucceedingTest() throws {


### PR DESCRIPTION
See this issue for more context: https://github.com/danger/swift/issues/513#issuecomment-1099137770

Basically; after GH introduced [their new PR experience](https://github.com/github/feedback/discussions/12341), things started to break on our side. The ability to report errors and warnings inline seems to be broken, so I temporarily disabled this feature for now.

### Running Danger locally
Testing and debugging Danger can be difficult sometimes, so I decided to create a `fastlane run_danger_locally` lane which simplifies this by a lot.

Fixes #145 