### PR TITLE
[No Ticket]: Refactoring fastlane script

### DIFF
--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -21,7 +21,8 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # Commenting this out for testing purposes only!
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -22,7 +22,7 @@ workflows:
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
             # Commenting this out for testing purposes only!
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}
     - script:

--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -21,7 +21,6 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # Commenting this out for testing purposes only!
             git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - bitrise-step-install-bundler: {}

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -77,7 +77,7 @@ lane :beta do |options|
 
   puts "Created release with URL: #{release_url}"
 
-  begin
+  # begin
     testflight(
       beta_app_review_info: {
         contact_email: options[:contact_email] || ENV['BETA_CONTACT_EMAIL'],
@@ -93,11 +93,11 @@ lane :beta do |options|
       changelog: stripped_changelog,
       team_id: options[:team_id] || ENV['FASTLANE_ITC_TEAM_ID']
     )
-  rescue StandardError => e
-    raise e unless e.message.include?('Another build is in review')
-
-    UI.important('TestFlight delivery failed because a build is already in review, but continuing anyway!')
-  end
+  # rescue StandardError => e
+  #   raise e unless e.message.include?('Another build is in review')
+  #
+  #   UI.important('TestFlight delivery failed because a build is already in review, but continuing anyway!')
+  # end
 
   slack_message(message: 'A new Release Candidate has been published.', tag_name: tag_name, release_url: release_url)
 end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -31,9 +31,8 @@ lane :beta do |options|
   scheme = options[:scheme] || ENV['XCODE_SCHEME']
 
   if is_changed_since_last_tag == false
-    releaseCanceledMessage = 'A new Release is cancelled as there are no changes since the last available tag.'
-    # slack_message(message: releaseCanceledMessage, tag_name: tag_name)
-    UI.user_error!(releaseCanceledMessage)
+    slack_message(message: 'A new Release is cancelled as there are no changes since the last available tag.', tag_name: tag_name)
+    break
   end
 
   clear_derived_data

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -36,7 +36,10 @@ lane :beta do |options|
     next
   end
 
-  clear_derived_data
+  if is_running_on_CI(options)
+    clear_derived_data
+  end
+
   build_number = update_build_number(xcodeproj: xcodeproj, target: target)
   tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
 

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -76,7 +76,7 @@ lane :beta do |options|
   changelog = release_json['changelog']
   stripped_changelog = strip_markdown_url(input: changelog)
 
-  puts "Created release with URL: #{release_url}"
+  UI.message "Created release with URL: #{release_url}"
 
   begin
     testflight(
@@ -179,7 +179,7 @@ lane :release do |options|
     changelog = release_json['changelog']
     stripped_changelog = strip_markdown_url(input: changelog)
 
-    puts "Created release with URL: #{release_url}"
+    UI.message "Created release with URL: #{release_url}"
 
     # Push the updated changelog.
     sh('git commit -a -m "Created a new release"')
@@ -232,7 +232,7 @@ lane :release do |options|
     stripped_changelog.prepend("This build has been submitted to the App Store.\n\n")
     testflight_groups = options[:groups] || ENV['TESTFLIGHT_GROUPS_RELEASE']
 
-    puts "Creating a TestFlight build which will be available to these groups: #{testflight_groups}"
+    UI.message "Creating a TestFlight build which will be available to these groups: #{testflight_groups}"
 
     testflight(
       beta_app_review_info: {
@@ -307,7 +307,7 @@ lane :appium_build do |options|
     cloned_source_packages_path: '.build'
   )
 
-  puts "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
+  UI.message "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
 end
 
 desc 'Generates a JWT token used for JWT authorization with the App Store Connect API.'
@@ -345,7 +345,7 @@ private_lane :is_changed_since_last_tag do
   sh "git fetch --tags origin #{ENV['BITRISE_GIT_BRANCH']} --no-recurse-submodules"
   last_tag = last_git_tag
   changes = sh "git diff --name-only HEAD #{last_tag}"
-  puts "Is local HEAD changed since last tag #{last_tag}: #{!changes.empty?}"
+  UI.message "Is local HEAD changed since last tag #{last_tag}: #{!changes.empty?}"
   is_changed = !changes.empty?
 end
 
@@ -371,14 +371,14 @@ private_lane :update_build_number do |options|
   test_flight_build_number = latest_testflight_build_number(version: version_number)
 
   if new_build_number <= latest_app_store_build_number
-    puts 'git build number is smaller than the build number of the latest release'
-    puts "Using the latest release build number #{latest_app_store_build_number} + 1"
+    UI.message 'git build number is smaller than the build number of the latest release'
+    UI.message "Using the latest release build number #{latest_app_store_build_number} + 1"
     new_build_number = latest_app_store_build_number + 1
   end
 
   if new_build_number <= test_flight_build_number
-    puts 'git build number is smaller than test flight build number'
-    puts "Using the TestFlight build number #{test_flight_build_number} + 1"
+    UI.message 'git build number is smaller than test flight build number'
+    UI.message "Using the TestFlight build number #{test_flight_build_number} + 1"
     new_build_number = test_flight_build_number + 1
   end
 
@@ -416,7 +416,7 @@ desc '#### Options'
 desc ' * **`app_identifier`**: The bundle identifier of the app for which to fetch the preparing version number'
 desc ''
 private_lane :current_preparing_app_version do |options|
-  puts 'fetching highest version on App Store Connect...'
+  UI.message 'fetching highest version on App Store Connect...'
 
   token = Spaceship::ConnectAPI::Token.create(Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY])
   Spaceship::ConnectAPI.token = token
@@ -424,16 +424,16 @@ private_lane :current_preparing_app_version do |options|
   app = Spaceship::ConnectAPI::App.find(options[:app_identifier])
 
   if app.nil?
-    puts 'App not found'
+    UI.message 'App not found'
     next
   end
 
   if app.get_edit_app_store_version.nil?
-    puts 'No preparing version number found'
+    UI.message 'No preparing version number found'
     next
   end
 
-  puts "Latest perparing version is #{app.get_edit_app_store_version.version_string}"
+  UI.message "Latest perparing version is #{app.get_edit_app_store_version.version_string}"
 
   app.get_edit_app_store_version.version_string
 end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -31,6 +31,7 @@ lane :beta do |options|
   scheme = options[:scheme] || ENV['XCODE_SCHEME']
 
   if is_changed_since_last_tag == false
+    tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
     slack_message(message: 'A new Release is cancelled as there are no changes since the last available tag.', tag_name: tag_name)
     next
   end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -32,7 +32,7 @@ lane :beta do |options|
 
   if is_changed_since_last_tag == false
     slack_message(message: 'A new Release is cancelled as there are no changes since the last available tag.', tag_name: tag_name)
-    break
+    next
   end
 
   clear_derived_data

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -77,6 +77,8 @@ lane :beta do |options|
 
   puts "Created release with URL: #{release_url}"
 
+  puts "[Debug]: #{stripped_changelog}"
+
   # begin
     testflight(
       beta_app_review_info: {

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -42,7 +42,7 @@ lane :beta do |options|
 
   UI.message "Proceeding to build app version: #{tag_name}"
 
-  if options[:ci] || ENV['CI'] == 'true'
+  if is_running_on_CI(options)
     certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'])
     prepare_for_ci
   end
@@ -213,7 +213,7 @@ lane :release do |options|
     # Create and submit the actual build.
     clear_derived_data
 
-    certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS']) if options[:ci] || ENV['CI'] == 'true'
+    certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS']) if is_running_on_CI(options)
 
     prepare_for_ci
 
@@ -300,7 +300,7 @@ lane :appium_build do |options|
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
   ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '120'
 
-  certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if options[:ci] || ENV['CI'] == 'true'
+  certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if is_running_on_CI(options)
 
   gym(
     scheme: scheme,
@@ -527,4 +527,11 @@ private_lane :create_tag_name do |options|
   version_number = get_version_number(xcodeproj: options[:xcodeproj], target: options[:target])
   build_number = get_build_number(xcodeproj: options[:xcodeproj])
   tag_name = version_number + 'b' + build_number
+end
+
+## Helper
+
+# Checks if the current environment is CI.
+def is_running_on_CI(options)
+  options[:ci] || ENV['CI'] == 'true'
 end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -39,6 +39,8 @@ lane :beta do |options|
   build_number = update_build_number(xcodeproj: xcodeproj, target: target)
   tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
 
+  UI.message "Proceeding to build app version: #{tag_name}"
+
   if options[:ci] || ENV['CI'] == 'true'
     certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'])
     prepare_for_ci

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -166,8 +166,8 @@ lane :release do |options|
     release_title = is_hotfix ? "#{tag_name} - App Store Hotfix Release" : "#{tag_name} - App Store Release"
 
     # Push the changes to our release branch so we can create a tag from it
-    sh('git commit -a -m "Created a new release"')
-    sh("git push origin #{branch_name}")
+    sh 'git commit -a -m "Created a new release"'
+    sh "git push origin #{branch_name}"
 
     release_latest_tag = is_hotfix ? latest_release_tag : last_non_candidate_tag
     release_base_branch = is_hotfix ? 'main' : 'develop'
@@ -182,8 +182,8 @@ lane :release do |options|
     UI.message "Created release with URL: #{release_url}"
 
     # Push the updated changelog.
-    sh('git commit -a -m "Created a new release"')
-    sh("git push origin #{branch_name}")
+    sh 'git commit -a -m "Created a new release"'
+    sh "git push origin #{branch_name}"
 
     repo = git_repository_name
 
@@ -272,7 +272,7 @@ lane :release do |options|
     # Delete 1 pre-release found before the release we just created.
     # This is temporarily set to 1 to test out. We can eventually increase this number slowly
     # so we will eventually clean up all pre-releases.
-    sh("mint run gitbuddy tagDeletion -u #{tag_name} -l 1 --prerelease-only --verbose")
+    sh "mint run gitbuddy tagDeletion -u #{tag_name} -l 1 --prerelease-only --verbose"
 
     # Currently doesn't work because as you can't download dsyms with an API key
     # upload_dsyms

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -32,7 +32,7 @@ lane :beta do |options|
 
   if is_changed_since_last_tag == false
     releaseCanceledMessage = 'A new Release is cancelled as there are no changes since the last available tag.'
-    slack_message(message: releaseCanceledMessage, tag_name: tag_name)
+    # slack_message(message: releaseCanceledMessage, tag_name: tag_name)
     UI.user_error!(releaseCanceledMessage)
   end
 
@@ -97,7 +97,7 @@ lane :beta do |options|
   #   UI.important('TestFlight delivery failed because a build is already in review, but continuing anyway!')
   # end
 
-  slack_message(message: 'A new Release Candidate has been published.', tag_name: tag_name, release_url: release_url)
+  # slack_message(message: 'A new Release Candidate has been published.', tag_name: tag_name, release_url: release_url)
 end
 
 desc 'Creates a new App Store Release'

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -78,9 +78,7 @@ lane :beta do |options|
 
   puts "Created release with URL: #{release_url}"
 
-  puts "[Debug]: #{stripped_changelog}"
-
-  # begin
+  begin
     testflight(
       beta_app_review_info: {
         contact_email: options[:contact_email] || ENV['BETA_CONTACT_EMAIL'],
@@ -94,13 +92,13 @@ lane :beta do |options|
       changelog: stripped_changelog,
       team_id: options[:team_id] || ENV['FASTLANE_ITC_TEAM_ID']
     )
-  # rescue StandardError => e
-  #   raise e unless e.message.include?('Another build is in review')
-  #
-  #   UI.important('TestFlight delivery failed because a build is already in review, but continuing anyway!')
-  # end
+  rescue StandardError => e
+    raise e unless e.message.include?('Another build is in review')
 
-  # slack_message(message: 'A new Release Candidate has been published.', tag_name: tag_name, release_url: release_url)
+    UI.important "TestFlight delivery failed because a build is already in review, but continuing anyway!"
+  end
+
+  slack_message(message: 'A new Release Candidate has been published.', tag_name: tag_name, release_url: release_url)
 end
 
 desc 'Creates a new App Store Release'

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -99,7 +99,9 @@ lane :beta do |options|
     UI.important "TestFlight delivery failed because a build is already in review, but continuing anyway!"
   end
 
-  slack_message(message: 'A new Release Candidate has been published.', tag_name: tag_name, release_url: release_url)
+  success_message = 'A new Release Candidate has been published.'
+  UI.success "#{success_message} #{tag_name}"
+  slack_message(message: success_message, tag_name: tag_name, release_url: release_url)
 end
 
 desc 'Creates a new App Store Release'

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -87,8 +87,6 @@ lane :beta do |options|
         demo_account_name: options[:demo_account_name] || ENV['BETA_DEMO_ACCOUNT_NAME'],
         demo_account_password: options[:demo_account_password] || ENV['BETA_DEMO_ACCOUNT_PASSWORD']
       },
-      skip_waiting_for_build_processing: false,
-      skip_submission: false,
       groups: options[:groups] || ENV['TESTFLIGHT_GROUPS_BETA'],
       changelog: stripped_changelog,
       team_id: options[:team_id] || ENV['FASTLANE_ITC_TEAM_ID']


### PR DESCRIPTION
## Description
This PR will basically change the following things:
- Introducing a `next` in case nothing has changes since the last tag was created (This change updated the indention across a few lines, so sorry for the messy code review in these lines 😞).
- We removed a few parameters from the TestFlight call because they were set to default values anyway (`skip_waiting_for_build_processing` and `skip_submission`).
- The log will now explicitly mention the next build version that's on its way.
- `puts` calls were replaced with `UI.message`.
- `sh` calls were unified.
- We'll have a `UI.success` message at the end of a beta build.
- The changelog is now safely truncated at 3900 characters (4000 being Apples limit).
- A helper method was added to check if we are building on CI.