### PR TITLE
[No Ticket]: Adds a note into the fastlane log, once a release was canceled

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -32,7 +32,9 @@ lane :beta do |options|
 
   if is_changed_since_last_tag == false
     tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
-    slack_message(message: 'A new Release is cancelled as there are no changes since the last available tag.', tag_name: tag_name)
+    cancel_message = 'A new Release is cancelled as there are no changes since the last available tag.'
+    slack_message(message: cancel_message, tag_name: tag_name)
+    UI.important cancel_message
     next
   end
 


### PR DESCRIPTION
## Description
This PR will add a note (level important / yellow) into the fastlane log, once a release was canceled due to no changes since the last build. Previously this note was only send into the slack channel, but not in the log.