### PR TITLE
Don't pass the tag name to use the latest tag instead for GitBuddy Deletion

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -272,7 +272,7 @@ lane :release do |options|
     # Delete 1 pre-release found before the release we just created.
     # This is temporarily set to 1 to test out. We can eventually increase this number slowly
     # so we will eventually clean up all pre-releases.
-    sh("mint run gitbuddy tagDeletion -u #{tag_name} -l 1 --prerelease-only --verbose")
+    sh("mint run gitbuddy tagDeletion -l 1 --prerelease-only --verbose")
 
     # Currently doesn't work because as you can't download dsyms with an API key
     # upload_dsyms


### PR DESCRIPTION
We used to pass in the `up-until-tag` into GitBuddy, which didn't work since the tag was not fetched locally yet. Instead, we can use GitBuddy's ability to fetch the latest tag. To do so, we need to remove passing in any tag.