### PR TITLE
Better slack messaging

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -3,6 +3,7 @@
 require 'spaceship'
 require 'uri'
 require 'json'
+import "helper.rb"
 
 desc 'Creates a new release candidate'
 desc ''
@@ -34,7 +35,7 @@ lane :beta do |options|
     tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
     cancel_message = 'A new Release is cancelled as there are no changes since the last available tag.'
     UI.important cancel_message
-    slack_message(message: cancel_message, tag_name: tag_name)
+    slack_message(":large_blue_circle: #{cancel_message}", tag_name: tag_name, default_payloads: [])
     next
   end
 
@@ -106,8 +107,8 @@ lane :beta do |options|
   end
 
   success_message = 'A new Release Candidate has been published.'
-  UI.success "#{success_message} #{tag_name}"
-  slack_message(message: success_message, tag_name: tag_name, release_url: release_url)
+  UI.success "#{success_message} (#{tag_name})"
+  slack_message(":tada: #{success_message}", tag_name: tag_name, release_url: release_url)
 end
 
 desc 'Creates a new App Store Release'
@@ -289,7 +290,9 @@ lane :release do |options|
     # upload_dsyms
 
     release_type = is_hotfix ? 'hotfix' : 'release'
-    slack_message(message: "A new #{release_type} has been submitted to the App Store.", tag_name: tag_name, release_url: release_url)
+    success_message = "A new #{release_type} has been submitted to the App Store."
+    UI.success "#{success_message} (#{tag_name})"
+    slack_message(":rocket: #{success_message}", tag_name: tag_name, release_url: release_url)
   rescue StandardError => e
     UI.error e
   end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -35,7 +35,7 @@ lane :beta do |options|
     tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
     cancel_message = 'A new Release is cancelled as there are no changes since the last available tag.'
     UI.important cancel_message
-    slack_message(":large_blue_circle: #{cancel_message}", tag_name: tag_name, default_payloads: [])
+    slack_message(cancel_message, type: :info, tag_name: tag_name, default_payloads: [])
     next
   end
 
@@ -108,7 +108,7 @@ lane :beta do |options|
 
   success_message = 'A new Release Candidate has been published.'
   UI.success "#{success_message} (#{tag_name})"
-  slack_message(":tada: #{success_message}", tag_name: tag_name, release_url: release_url)
+  slack_message(success_message, type: :release_build, tag_name: tag_name, release_url: release_url)
 end
 
 desc 'Creates a new App Store Release'
@@ -292,7 +292,7 @@ lane :release do |options|
     release_type = is_hotfix ? 'hotfix' : 'release'
     success_message = "A new #{release_type} has been submitted to the App Store."
     UI.success "#{success_message} (#{tag_name})"
-    slack_message(":rocket: #{success_message}", tag_name: tag_name, release_url: release_url)
+    slack_message(success_message, type: :submitted, tag_name: tag_name, release_url: release_url)
   rescue StandardError => e
     UI.error e
   end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -536,21 +536,3 @@ private_lane :create_tag_name do |options|
   build_number = get_build_number(xcodeproj: options[:xcodeproj])
   tag_name = version_number + 'b' + build_number
 end
-
-## Helper
-
-# Checks if the current environment is CI.
-def is_running_on_CI(options)
-  options[:ci] || ENV['CI'] == 'true'
-end
-
-# Truncates a given string to a certain length and adds a truncation mark in the
-# end if the string is long enough.
-def truncate(string, max)
-  truncation_mark = '...'
-  if string.length > max
-    max > truncation_mark.length ? "#{string[0...max-truncation_mark.length]}#{truncation_mark}" : "#{string[0...max]}"
-  else
-    string
-  end
-end

--- a/Fastlane/helper.rb
+++ b/Fastlane/helper.rb
@@ -24,6 +24,7 @@ end
 # It is required to create an incoming Webhook for Slack and set this as an environment variable `SLACK_URL`.
 #
 # ==== Options
+# * type - adds an emoji to easier identify the messages context ([:error, :info, :release_build, :submitted]).
 # * tag_name - adds the tag name at the end of the given slack message.
 # * success - was this build successful? (true/false) Default is true.
 # * default_payloads - Specifies default payloads to include. Pass an empty array to suppress all the default payloads ([:git_branch]).
@@ -31,7 +32,15 @@ end
 def slack_message(message, options = {})
   return if message.empty?
 
-  slack_message = message << (options[:tag_name] && !options[:tag_name].empty? ? " (#{options[:tag_name]})" : "")
+  supported_types = {
+    error: ":x: ",
+    info: ":large_blue_circle: ",
+    release_build: ":tada: ",
+    submitted: ":rocket: "
+  }
+
+  slack_message_tag = " (#{options[:tag_name]})" if options[:tag_name] && !options[:tag_name].empty?
+  slack_message = "#{supported_types[options[:type]]}#{message}#{slack_message_tag}"
   slack_success = !!options[:success] == options[:success] ? options[:success] : true
   default_payloads = options[:default_payloads] ? options[:default_payloads] : [:git_branch]
   slack_payload = {}

--- a/Fastlane/helper.rb
+++ b/Fastlane/helper.rb
@@ -28,6 +28,7 @@ end
 # * tag_name - adds the tag name at the end of the given slack message.
 # * success - was this build successful? (true/false) Default is true.
 # * default_payloads - Specifies default payloads to include. Pass an empty array to suppress all the default payloads ([:git_branch]).
+# * additional_payloads - Additional payloads to be added to the slack message. A hash is expected.
 # * release_url - URL to be added as payload.
 def slack_message(message, options = {})
   return if message.empty?
@@ -45,6 +46,7 @@ def slack_message(message, options = {})
   default_payloads = options[:default_payloads] ? options[:default_payloads] : [:git_branch]
   slack_payload = {}
   slack_payload['Release URL'] = options[:release_url] if options[:release_url] && !options[:release_url].empty?
+  slack_payloads.merge!(options[:additional_payloads]) if options[:additional_payloads]
 
   slack(
     message: slack_message,

--- a/Fastlane/helper.rb
+++ b/Fastlane/helper.rb
@@ -1,0 +1,46 @@
+# rubocop:disable Layout/LineLength
+
+## Helper
+
+# Checks if the current environment is CI.
+def is_running_on_CI(options)
+  options[:ci] || ENV['CI'] == 'true'
+end
+
+# Truncates a given string to a certain length and adds a truncation mark in the
+# end if the string is long enough.
+def truncate(string, max)
+  return if string.empty?
+
+  truncation_mark = '...'
+  if string.length > max
+    max > truncation_mark.length ? "#{string[0...max-truncation_mark.length]}#{truncation_mark}" : "#{string[0...max]}"
+  else
+    string
+  end
+end
+
+# Posts a message about the status of a build to Slack.
+# It is required to create an incoming Webhook for Slack and set this as an environment variable `SLACK_URL`.
+#
+# ==== Options
+# * tag_name - adds the tag name at the end of the given slack message.
+# * success - was this build successful? (true/false) Default is true.
+# * default_payloads - Specifies default payloads to include. Pass an empty array to suppress all the default payloads ([:git_branch]).
+# * release_url - URL to be added as payload.
+def slack_message(message, options = {})
+  return if message.empty?
+
+  slack_message = message << (options[:tag_name] && !options[:tag_name].empty? ? " (#{options[:tag_name]})" : "")
+  slack_success = !!options[:success] == options[:success] ? options[:success] : true
+  default_payloads = options[:default_payloads] ? options[:default_payloads] : [:git_branch]
+  slack_payload = {}
+  slack_payload['Release URL'] = options[:release_url] if options[:release_url] && !options[:release_url].empty?
+
+  slack(
+    message: slack_message,
+    success: slack_success,
+    default_payloads: default_payloads,
+    payload: slack_payload
+  )
+end

--- a/Fastlane/shared_lanes.rb
+++ b/Fastlane/shared_lanes.rb
@@ -36,29 +36,10 @@ lane :latest_github_release do
   result[:json]['tag_name']
 end
 
-desc 'Posts a message about the status of a build to Slack'
-desc 'It is required to create an incoming Webhook for Slack and set this as an environment variable `SLACK_URL`'
-desc ''
-desc '#### Options'
-desc ' * **`message**`: The message to post to Slack'
-desc ' * **`tag_name**`: The name of the tag associated with the build'
-desc ' * **`release_url`**: The url to a GH release.'
-desc ''
-lane :slack_message do |options|
-  slack(
-    message: "#{options[:message]} (#{options[:tag_name]})",
-    success: true,
-    default_payloads: %i[git_branch last_git_commit_message],
-    payload: {
-      'Release URL' => options[:release_url]
-    }
-  )
-end
-
 desc 'Runs danger locally for the given PR ID.'
 lane :run_danger_locally do
   pr_id = prompt(text: 'Enter the pull request identifier: ', ci_input: "3")
-  
+
   origin_name = git_repository_name.split('/')
   organisation = origin_name[0]
   repository = origin_name[1]
@@ -67,7 +48,7 @@ lane :run_danger_locally do
   ENV["BITRISEIO_GIT_REPOSITORY_OWNER"] = organisation
   ENV["BITRISEIO_GIT_REPOSITORY_SLUG"] = repository
   ENV["BITRISE_PULL_REQUEST"] = pr_id
-  
+
   # By changing directory into WeTransfer-iOS-CI, we can run Danger from there.
   # Caching is still done per repository which is why we add the build and cache paths.
   # --cwd makes sure to run Danger in the current repository directory


### PR DESCRIPTION
## Description
This PR will introduce a new helper method (slack_message) to easier send out more clearly communicated slack messages.
Not needed informations will no longer be broadcasted and a clear difference between the different types on message contexts will be added.
Additionally we'll add support for more message payloads in case there is more to say (error handling PR will be opened on Mule).