### PR TITLE
Increment number of pre-releases to delete during a release

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -280,10 +280,10 @@ lane :release do |options|
       }
     )
 
-    # Delete 1 pre-release found before the release we just created.
-    # This is temporarily set to 1 to test out. We can eventually increase this number slowly
+    # Delete 10 pre-releases found before the release we just created.
+    # This is temporarily set to 10 to test out. We can eventually increase this number slowly
     # so we will eventually clean up all pre-releases.
-    sh "mint run gitbuddy tagDeletion -l 1 --prerelease-only --verbose"
+    sh "mint run gitbuddy tagDeletion -l 10 --prerelease-only --verbose"
 
     # Currently doesn't work because as you can't download dsyms with an API key
     # upload_dsyms


### PR DESCRIPTION
It was set to 1 to test things out. Since it works as expected, we can increase the number.

Fixes [TMOB-349]