### PR TITLE
Revert pre-commit change

### DIFF
--- a/BuildTools/swiftformat.sh
+++ b/BuildTools/swiftformat.sh
@@ -12,8 +12,5 @@ if [ -z "$CI" ]; then
         xcrun --sdk macosx mint bootstrap -m $MINT_FILE_PATH
     fi
 
-    git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read file; do
-        xcrun --sdk macosx mint run -m $MINT_FILE_PATH $SWIFT_FORMAT --config "$BASEDIR/.swiftformat" "${file}";
-        git add "$file";
-    done
+    xcrun --sdk macosx mint run -m $MINT_FILE_PATH $SWIFT_FORMAT --config "$BASEDIR/.swiftformat" .
 fi


### PR DESCRIPTION
The changes introduced in https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/174 didn't consider the submodules, so for now we're reverting it.

I'll later investigate how we can make sure the submodules changes are also formatted.