### PR TITLE
[TMOB-1254]: reverting changes

### DIFF
--- a/Fastlane/shared_lanes.rb
+++ b/Fastlane/shared_lanes.rb
@@ -113,11 +113,7 @@ def slack_message(message, options = {})
     message: slack_message,
     success: slack_success,
     default_payloads: default_payloads,
-    payload: slack_payload,
-    attachment_properties: {
-      author_name: "Fastlane (iOS)",
-      author_icon: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Apple_Computer_Logo_rainbow.svg/206px-Apple_Computer_Logo_rainbow.svg.png"
-    }
+    payload: slack_payload
   )
 end
 


### PR DESCRIPTION
## Description
This PR will revert the changes introduced in #179 because the outcome was not as expected:
https://wetransfer.slack.com/archives/C03L6QCFR8E/p1656327016900699

A better solution has been found by creating a custom SlackApp (iOS Release), which will now be used to post iOS releases on the channel.