### PR TITLE
Error handling - method error_info not working

### DIFF
--- a/Fastlane/shared_lanes.rb
+++ b/Fastlane/shared_lanes.rb
@@ -148,7 +148,7 @@ def handle_error(lane, exception)
     success: false,
     additional_payloads: {
       "Bitrise build" => ENV['BITRISE_BUILD_URL'],
-      "Error Info" => exception.error_info.to_s
+      "Error Info" => exception.to_s
     }
   )
 end


### PR DESCRIPTION
## Description
`error` objects outside of the fastlane context do not support `error_info`.
We should use the ruby default instead.