### PR TITLE
Use last_git_tag instead of last release tag

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -31,7 +31,7 @@ lane :beta do |options|
   scheme = options[:scheme] || ENV['XCODE_SCHEME']
 
   if is_changed_since_last_tag == false
-    tag_name = create_tag_name(xcodeproj: xcodeproj, target: target)
+    tag_name = last_git_tag
     cancel_message = 'A new Beta build has been cancelled as there are no changes since the last available tag.'
     UI.important cancel_message
     slack_message(cancel_message, type: :info, tag_name: tag_name, default_payloads: [])


### PR DESCRIPTION
## Description
This PR will change the "error" message in case there was no new (beta) version build, due to no changes.
Previously the wording was wrong, because it claimed there has been no changes since the last release version. Actually it was comparing current HEAD to the last_git_tag already.


## Screenshot
![Screenshot 2022-07-04 at 15 35 44](https://user-images.githubusercontent.com/134348/177165984-15e48d51-5949-41a0-bf55-e8299b425992.png)

