### PR TITLE
Deploy Simulator Build

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -121,13 +121,7 @@ workflows:
         - is_enable_public_page: 'false'
         - is_compress: 'true'
         - debug_mode: 'true'
-        - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_SCHEME}.app/
-    - script:
-        title: Make Simulator Build Download URL available
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            export SIMULATOR_BUILD_DOWNLOAD_URL=BITRISE_PERMANENT_DOWNLOAD_URL_MAP["${XCODE_SCHEME}.app.zip"]    
+        - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_TARGET}.app/  
     - script:
         title: Run Danger
         deps:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -118,7 +118,7 @@ workflows:
         is_skippable: true
         inputs:
         - notify_user_groups: none
-        - is_enable_public_page: 'false'
+        - is_enable_public_page: 'true'
         - is_compress: 'true'
         - debug_mode: 'true'
         - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_TARGET}.app/  

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -123,6 +123,12 @@ workflows:
         - debug_mode: 'true'
         - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_SCHEME}.app/
     - script:
+        title: Make Simulator Build Download URL available
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            export SIMULATOR_BUILD_DOWNLOAD_URL=BITRISE_PERMANENT_DOWNLOAD_URL_MAP["${XCODE_SCHEME}.app.zip"]    
+    - script:
         title: Run Danger
         deps:
           brew:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -93,7 +93,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -118,7 +118,7 @@ workflows:
         is_skippable: true
         inputs:
         - notify_user_groups: none
-        - is_enable_public_page: 'true'
+        - is_enable_public_page: 'false'
         - is_compress: 'true'
         - debug_mode: 'true'
         - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_TARGET}.app/  

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -93,7 +93,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI
@@ -113,6 +113,15 @@ workflows:
             # Use the environment FASTLANE_LANE if available. Otherwise, fallback to "test"
             lane=${FASTLANE_LANE:=test}
             fastlane $lane
+    - deploy-to-bitrise-io@2:
+        title: Deploy Simulator Build to Bitrise
+        is_skippable: true
+        inputs:
+        - notify_user_groups: none
+        - is_enable_public_page: 'false'
+        - is_compress: 'true'
+        - debug_mode: 'true'
+        - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_SCHEME}.app/
     - script:
         title: Run Danger
         deps:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -93,7 +93,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -138,8 +138,13 @@ public enum WeTransferPRLinter {
         using danger: DangerDSL,
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        print(environmentVariables["BITRISE_PERMANENT_DOWNLOAD_URL_MAP"])
-        guard let url = environmentVariables["SIMULATOR_BUILD_DOWNLOAD_URL"] else {
+        // Sample value in BITRISE_PERMANENT_DOWNLOAD_URL_MAP:
+        // "Transfer.app.zip=>https://..."
+        guard let map = environmentVariables["BITRISE_PERMANENT_DOWNLOAD_URL_MAP"]?.components(separatedBy: ","),
+              let targetName = environmentVariables["XCODE_TARGET"],
+              let simulatorBuildDownloadURL = map.first(where: { $0.hasPrefix("\(targetName).app.zip") }),
+              let url = simulatorBuildDownloadURL.components(separatedBy: "=>").last
+        else {
             print("Simulator build download URL not found")
             return
         }

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -138,7 +138,7 @@ public enum WeTransferPRLinter {
         using danger: DangerDSL,
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        // Sample value in BITRISE_PERMANENT_DOWNLOAD_URL_MAP:
+        // Example value in BITRISE_PERMANENT_DOWNLOAD_URL_MAP:
         // "Transfer.app.zip=>https://..."
         guard let map = environmentVariables["BITRISE_PERMANENT_DOWNLOAD_URL_MAP"]?.components(separatedBy: ","),
               let targetName = environmentVariables["XCODE_TARGET"],

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -138,7 +138,8 @@ public enum WeTransferPRLinter {
         using danger: DangerDSL,
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        guard let url = environmentVariables["BITRISE_PERMANENT_DOWNLOAD_URL_MAP"] else {
+        print(environmentVariables["BITRISE_PERMANENT_DOWNLOAD_URL_MAP"])
+        guard let url = environmentVariables["SIMULATOR_BUILD_DOWNLOAD_URL"] else {
             print("Simulator build download URL not found")
             return
         }

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -39,6 +39,10 @@ public enum WeTransferPRLinter {
             showBitriseBuildURL(using: danger, environmentVariables: environmentVariables)
         }
 
+        measure(taskName: "Simulator Download URL showing") {
+            showSimulatorBuildDownloadURL(using: danger, environmentVariables: environmentVariables)
+        }
+
         measure(taskName: "SwiftLint") {
             swiftLint(using: danger, executor: swiftLintExecutor, configsFolderPath: swiftLintConfigsFolderPath, fileManager: fileManager)
         }
@@ -127,6 +131,18 @@ public enum WeTransferPRLinter {
             return
         }
         danger.message("View more details on <a href=\"\(bitriseURL)\" target=\"_blank\">Bitrise</a>")
+    }
+
+    /// Show the simulator build download URL.
+    static func showSimulatorBuildDownloadURL(
+        using danger: DangerDSL,
+        environmentVariables: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        guard let url = environmentVariables["BITRISE_PERMANENT_DOWNLOAD_URL_MAP"] else {
+            print("Simulator build download URL not found")
+            return
+        }
+        danger.message("Download <a href=\"\(url)\" target=\"_blank\">Simulator Build</a>")
     }
 
     /// Triggers SwiftLint.

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
@@ -125,6 +125,19 @@ final class WeTransferLinterTests: XCTestCase {
         XCTAssertEqual(danger.messages.first?.message, "View more details on <a href=\"\(bitriseURL)\" target=\"_blank\">Bitrise</a>")
     }
 
+    /// It should show the Simulator Build Download URL if it's set.
+    func testSimulatorBuildDownloadURL() {
+        let danger = DangerDSL(testSettings: [:])
+        let url = "https://example.com"
+        let targetName = "TargetName"
+        WeTransferPRLinter.showSimulatorBuildDownloadURL(using: danger, environmentVariables: [
+            "BITRISE_PERMANENT_DOWNLOAD_URL_MAP": "\(targetName).app.zip=>\(url)",
+            "XCODE_TARGET": targetName
+        ])
+        XCTAssertEqual(danger.messages.count, 1)
+        XCTAssertEqual(danger.messages.first?.message, "Download <a href=\"\(url)\" target=\"_blank\">Simulator Build</a>")
+    }
+
     /// It should not trigger SwiftLint if there's no files to lint.
     func testSwiftLintSkippingForNoSwiftFiles() {
         let danger = githubWithFilesDSL(created: ["Changelog.md", "RubyTests.rb"], fileMap: [:])


### PR DESCRIPTION
This PR deploys the simulator build to Bitrise and adds the download URL to the PR.

Unfortunately, the download URL is private and you need to log in to Bitrise.
There is [a way](https://gist.github.com/Marchuck/de230ed681428d47ce1276c14788ef9a#file-print_out_artifact_urls-sh) to generate a public URL for artifacts via Bitrise API but the URL expires in 10 minutes. 

Here is [a feature request](https://discuss.bitrise.io/t/expose-url-to-artifact-outside-of-build-page-public-install-page-for-non-app-artifacts-pkg-zip/2330) for permanent artifact download URL on Bitrise  
