### PR TITLE
Do not report errors happening other than on CI

### DIFF
--- a/Fastlane/shared_lanes.rb
+++ b/Fastlane/shared_lanes.rb
@@ -138,6 +138,7 @@ end
 # Errors being raised on the test lane (PR tests) will be ignore, because they could lead to too much spam on the slack channel.
 def handle_error(lane, exception)
   return if lane == :test # Do not report errors on PR tests.
+  return unless is_running_on_CI # Do not report errors on other environments than CI.
 
   # Makes sure we clean up the tag and the release branch if release_from_tag failed, to allow future releases
   clean_up_release_from_tag if lane == :release_from_tag

--- a/Fastlane/shared_lanes.rb
+++ b/Fastlane/shared_lanes.rb
@@ -64,8 +64,8 @@ end
 ## Helper
 
 # Checks if the current environment is CI.
-def is_running_on_CI(options)
-  options[:ci] || ENV['CI'] == 'true'
+def is_running_on_CI(options = nil)
+  (options != nil ? options[:ci] : false) || ENV['CI'] == 'true'
 end
 
 # Truncates a given string to a certain length and adds a truncation mark in the


### PR DESCRIPTION
## Description
Our slack channel started to get very noisy from fastlane errors happening on a local machine.
This PR will focus on CI only.