### PR TITLE
install certificates seperately for xctest builds

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -312,7 +312,7 @@ lane :appium_build do |options|
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
   ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '120'
 
-  certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if is_running_on_CI(options)
+  install_certs
 
   gym(
     scheme: scheme,
@@ -323,6 +323,12 @@ lane :appium_build do |options|
   )
 
   UI.message "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
+end
+
+desc 'Just install the certs onto bitrise so this can build for test lab'
+lane :install_certs do
+  clear_derived_data
+  certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if is_running_on_CI(options)
 end
 
 desc 'Generates a JWT token used for JWT authorization with the App Store Connect API.'

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -325,7 +325,7 @@ lane :appium_build do |options|
   UI.message "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
 end
 
-desc 'Just install the certs onto bitrise so this can build for test lab'
+desc 'install the certificates onto Bitrise so this can build for test lab'
 lane :install_certs do
   clear_derived_data
   certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if is_running_on_CI(options)

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -326,7 +326,7 @@ lane :appium_build do |options|
 end
 
 desc 'install the certificates onto Bitrise so this can build for test lab'
-lane :install_certs do
+lane :install_certificates do
   clear_derived_data
   certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if is_running_on_CI(options)
 end

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -312,7 +312,7 @@ lane :appium_build do |options|
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
   ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '120'
 
-  install_certs
+  install_certificates
 
   gym(
     scheme: scheme,
@@ -325,9 +325,8 @@ lane :appium_build do |options|
   UI.message "IPA saved at #{ENV['IPA_OUTPUT_PATH']}"
 end
 
-desc 'install the certificates onto Bitrise so this can build for test lab'
+desc 'install the certificates onto Bitrise so this can build for firebase test lab'
 lane :install_certificates do
-  clear_derived_data
   certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'], type: 'development') if is_running_on_CI(options)
 end
 


### PR DESCRIPTION
To create a build artefact for firebase test lab, have to install certificates separately. 
Also I shall be reusing this lane for appium_build lane