### PR TITLE
Execute `prepare_for_ci` only if `is_running_on_CI`

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -219,9 +219,10 @@ lane :release do |options|
     # Create and submit the actual build.
     clear_derived_data
 
-    certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS']) if is_running_on_CI(options)
-
-    prepare_for_ci
+    if is_running_on_CI(options)
+      certs(app_identifier: options[:app_identifiers] || ENV['APP_IDENTIFIERS'])
+      prepare_for_ci
+    end
 
     # Set timeout to prevent xcodebuild -list -project to take to much retries.
     ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'


### PR DESCRIPTION
Part of [TMOB-1799].

This PR makes sure we only run `prepare_for_ci` if `is_running_on_CI` in the `release` lane. 

[TMOB-1799]: https://wetransfer.atlassian.net/browse/TMOB-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ