### PR TITLE
[Datadog] Only enable CI once API Key exists

### DIFF
--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -84,6 +84,7 @@ desc 'To enable Datadog CI Tests Tracing for your project:'
 desc ' 1. Add the DD_API_KEY env variable as a secret to Bitrise'
 desc ' 2. Link the DatadogSDKTesting package following instructions here: https://docs.datadoghq.com/continuous_integration/setup_tests/swift/'
 lane :configure_datadog_ci_test_tracing do |options|
+  next unless ENV.has_value?("TEST_RUNNER_DD_API_KEY")
   ENV["TEST_RUNNER_DD_TEST_RUNNER"] = '1' 
   ENV["TEST_RUNNER_DD_ENV"] = 'ci' 
   ENV["TEST_RUNNER_DD_SITE"] = 'datadoghq.eu'

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -84,7 +84,7 @@ desc 'To enable Datadog CI Tests Tracing for your project:'
 desc ' 1. Add the DD_API_KEY env variable as a secret to Bitrise'
 desc ' 2. Link the DatadogSDKTesting package following instructions here: https://docs.datadoghq.com/continuous_integration/setup_tests/swift/'
 lane :configure_datadog_ci_test_tracing do |options|
-  next unless ENV.has_value?("TEST_RUNNER_DD_API_KEY")
+  next unless ENV.has_value?("DD_API_KEY")
   ENV["TEST_RUNNER_DD_TEST_RUNNER"] = '1' 
   ENV["TEST_RUNNER_DD_ENV"] = 'ci' 
   ENV["TEST_RUNNER_DD_SITE"] = 'datadoghq.eu'


### PR DESCRIPTION
We always enabled CI Tracing using `ENV["TEST_RUNNER_DD_TEST_RUNNER"] = '1'` but that allowed the Datadog Testing SDK to verify setup, resulting in an `exit(0)` if the API key didn't exist. 

This code change ensures we never fail unit tests run on CI if the API Key is not set.