### PR TITLE
Enable signed commits for open source

### DIFF
--- a/Bitrise/tag_releasing_bitrise.yml
+++ b/Bitrise/tag_releasing_bitrise.yml
@@ -35,6 +35,19 @@ workflows:
             mint install WeTransfer/GitBuddy
         title: Brew install
     - script:
+        title: Set up signed commits
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo -e $GPG_KEY | gpg --import
+            
+            # Let'em know who is pushing commits to our branches!
+            git config --global user.name "wetransferplatform"
+            git config --global user.email "platform+github@wetransfer.com"
+            git config --global user.signinkey "$WETRANSFERPLATFORM_SIGNIN_KEY"
+            git config --global commit.gpgSign true
+            git config --global tag.gpgSign true      
+    - script:
         title: Run Fastlane
         inputs:
         - content: |-
@@ -62,3 +75,9 @@ workflows:
             $BREW_MINT
             $BREW_OPT_MINT
             .build
+app:
+  envs:
+  - opts:
+      is_expand: true
+      is_required: true
+    GPG_KEY: $WETRANSFERPLATFORM_GPG_KEY


### PR DESCRIPTION
Our open-source repos require signed commits, so we have to enable signed commits for our release workflows.

Fixes [TMOB-1933]

[TMOB-1933]: https://wetransfer.atlassian.net/browse/TMOB-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ