### PR TITLE
Remove localization check and run CI normally

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -74,11 +74,6 @@ workflows:
                 echo 'Cancelling CI run since the PR is in draft'
                 exit 1
             fi
-
-            if [[ "$BITRISE_GIT_BRANCH" == *"smartling-content"* ]]; then
-                echo 'Cancelling CI run since the PR is for translations only'
-                exit 1
-            fi
     - cache-pull: {}
     - script:
         run_if: .IsCI


### PR DESCRIPTION
We used to let a CI run fail for smartling-only branches. However, that means our Danger check doesn't succeed and we're unable to merge in our PRs.
Secondly, unit tests can depend on translations, so we should actually run our suite of tests normally for localization only PRs. Therefore, I've removed the check.