### PR TITLE
Restore cache paths for Danger

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -139,10 +139,10 @@ workflows:
 
             if [ "$BITRISEIO_GIT_REPOSITORY_SLUG" == "WeTransfer-iOS-CI" ]; then
                 chmod +x danger-swift
-                ./danger-swift ci
+                ./danger-swift ci --cache-path .build --build-path .build
             else
                 cd Submodules/WeTransfer-iOS-CI
-                ./danger-swift ci --cwd ../../
+                ./danger-swift ci --cwd ../../ --cache-path ../../.build --build-path ../../.build
             fi
     - deploy-to-bitrise-io@2:
         is_skippable: true


### PR DESCRIPTION
We removed the cache directories in [this PR](https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/203/files) since I assumed we didn't need them anymore now that we have an executable for Danger. However, it turns out that we're still fetching packages specifically for the Danger plugins we define inside this repository.

It's not worth optimizing those dependencies into Binary frameworks or such, but we can optimize and benefit from caching at the very least. 