### PR TITLE
See if this fixes CI by fetching packages as part of scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 junit-results.xml
 .build
 node_modules
-.swiftpm
 build
 *.xcodeproj
 Fastlane/report.xml

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -90,7 +90,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -90,7 +90,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -44,11 +44,6 @@ lane :test_project do |options|
       service_name: scheme
     )
 
-    # resolve_spm_packages(
-    #   source_packages_dir: source_packages_dir,
-    #   package_path: options[:package_path]
-    # ) unless options.fetch(:disable_automatic_package_resolution, false)
-
     scan(
       scheme: scheme,
       project: project_path,
@@ -81,14 +76,6 @@ lane :test_project do |options|
       UI.important("Tests failed for #{e}")
     end
   end
-end
-
-desc 'Resolves packages in a separate lane so we can monitor performance of it based on caching.'
-private_lane :resolve_spm_packages do |options|
-  source_packages_dir = options[:source_packages_dir]
-  resolve_command = "xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath #{source_packages_dir}"
-  resolve_command.prepend("cd #{ENV['PWD']}/#{options[:package_path]} && ") unless options[:package_path].nil?
-  sh(resolve_command)
 end
 
 desc 'Configures environment variables to enable Datadog CI Tests Tracing'

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -44,10 +44,10 @@ lane :test_project do |options|
       service_name: scheme
     )
 
-    resolve_spm_packages(
-      source_packages_dir: source_packages_dir,
-      package_path: options[:package_path]
-    ) unless options.fetch(:disable_automatic_package_resolution, false)
+    # resolve_spm_packages(
+    #   source_packages_dir: source_packages_dir,
+    #   package_path: options[:package_path]
+    # ) unless options.fetch(:disable_automatic_package_resolution, false)
 
     scan(
       scheme: scheme,
@@ -72,7 +72,7 @@ lane :test_project do |options|
       build_for_testing: options.fetch(:build_for_testing, nil),
       test_without_building: options.fetch(:test_without_building, nil),
       disable_package_automatic_updates: true, # Makes xcodebuild -showBuildSettings more reliable too.
-      skip_package_dependencies_resolution: true
+      skip_package_dependencies_resolution: options.fetch(:disable_automatic_package_resolution, false)
     )
   rescue StandardError => e
     if options.fetch(:raise_exception_on_failure, false)

--- a/WeTransferPRLinter/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/WeTransferPRLinter/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -70,5 +70,5 @@ workflows:
 meta:
   bitrise.io:
     machine_type: standard
-    stack: osx-xcode-14.0.x
+    stack: osx-xcode-14.1.x
     machine_type_id: g2.4core


### PR DESCRIPTION
While we introduced this change in [this PR](https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/204/files#diff-1aa9e75b21f987435cd386618fa281f6dde84a921bcd54917e225cb3dd203016R47) to enable us to evaluate SPM separately, it turned out to mess up with Xcode on CI since `xcodebuild` itself wants to resolve packages during the build even though they were already resolved.

It lead to complicated errors, like:

```
sh: line 1:  2361 Abort trap: 6           env NSUnbufferedIO=YES xcodebuild -scheme CoreUIKit -destination ‘platform=iOS Simulator,id=72C3AE83-9A62-4CE8-BCC5-EAA3D56F8FB4’ -derivedDataPath /Users/vagrant/git/build/derived_data -resultBundlePath ‘/Users/vagrant/git/build/reports/CoreUIKit.xcresult’ -disable-concurrent-testing -enableCodeCoverage YES -clonedSourcePackagesDirPath /Users/vagrant/git/.spm-build -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 build test
      2362 Done                    | tee ‘/Users/vagrant/deploy/CoreUIKit.log’
      2363 Done                    | xcbeautify
[10:00:09]: Exit status: 134
```

Altogether, I decided to revert this back and to rely more on `xcodebuild`, reducing the number of failures we could potentially run into.