### PR TITLE
Introduce a CI Testing mode

### DIFF
--- a/Bitrise/Scripts/pr_assignments.sh
+++ b/Bitrise/Scripts/pr_assignments.sh
@@ -1,20 +1,5 @@
-# We can have both HTTPS and SSH urls.
-# HTTPS: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
-# SSH: git@github.com:WeTransfer/Mule.git
-#
-# Given the difference in URLs, the shared component is the last one (e.g. Mule.git).
-# It's first needed to reverse the URL, split it by `.` and get the second part of it (the -f2 in `cut`),
-# enabling to equate the URL split:
-#   - URL: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
-#   - Reversed: tig.IC-SOi-refsnarTeW/refsnarTeW/moc.buhtig//:sptth
-#   - Sectioned: [1: tig].[2: IC-SOi-refsnarTeW/refsnarTeW/moc].[3: buhtig//:sptth]
-# The previous split is the input to the next one, this time by `/`, and then the first element is used (the -f1 in `cut`).
-#   - Input: IC-SOi-refsnarTeW/refsnarTeW/moc
-#   - Sectioned: [1: IC-SOi-refsnarTeW]/[2: refsnarTeW]/[3: moc]
-# And lastly, we revert the result one more time, as the result will be reversed otherwise.
-REPOSITORY_NAME=$(echo ${GIT_REPOSITORY_URL} | rev | cut -d '.' -f2 | cut -d '/' -f1 | rev)
-ISSUE_URL="https://api.github.com/repos/${BITRISEIO_GIT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${BITRISE_PULL_REQUEST}"
-HEADER="Accept: application/vnd.github.v3+json"
+app="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source $app/setup_environment.sh
 
 PR_ASSIGNESS=$(
   curl \

--- a/Bitrise/Scripts/pr_assignments.sh
+++ b/Bitrise/Scripts/pr_assignments.sh
@@ -1,0 +1,51 @@
+# We can have both HTTPS and SSH urls.
+# HTTPS: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
+# SSH: git@github.com:WeTransfer/Mule.git
+#
+# Given the difference in URLs, the shared component is the last one (e.g. Mule.git).
+# It's first needed to reverse the URL, split it by `.` and get the second part of it (the -f2 in `cut`),
+# enabling to equate the URL split:
+#   - URL: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
+#   - Reversed: tig.IC-SOi-refsnarTeW/refsnarTeW/moc.buhtig//:sptth
+#   - Sectioned: [1: tig].[2: IC-SOi-refsnarTeW/refsnarTeW/moc].[3: buhtig//:sptth]
+# The previous split is the input to the next one, this time by `/`, and then the first element is used (the -f1 in `cut`).
+#   - Input: IC-SOi-refsnarTeW/refsnarTeW/moc
+#   - Sectioned: [1: IC-SOi-refsnarTeW]/[2: refsnarTeW]/[3: moc]
+# And lastly, we revert the result one more time, as the result will be reversed otherwise.
+REPOSITORY_NAME=$(echo ${GIT_REPOSITORY_URL} | rev | cut -d '.' -f2 | cut -d '/' -f1 | rev)
+ISSUE_URL="https://api.github.com/repos/${BITRISEIO_GIT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${BITRISE_PULL_REQUEST}"
+HEADER="Accept: application/vnd.github.v3+json"
+
+PR_ASSIGNESS=$(
+  curl \
+    -s \
+    -u ${GITBUDDY_ACCESS_TOKEN} \
+    -H ${HEADER} \
+    ${ISSUE_URL} \
+    | jq -r '.assignees[] | .login'
+)
+
+if [ -z ${PR_ASSIGNESS} ]; then
+  echo "PR assignees is empty. Continuing..."
+else
+  echo "PR assignees is not empty: ${PR_ASSIGNESS}. Nothing to do here..."
+  exit 0
+fi
+
+PR_AUTHOR=$(
+  curl \
+    -s \
+    -u ${GITBUDDY_ACCESS_TOKEN} \
+    -H ${HEADER} \
+    ${ISSUE_URL} \
+    | jq -r .user.login
+)
+
+curl \
+  -s \
+  -u ${GITBUDDY_ACCESS_TOKEN} \
+  -X POST \
+  -H ${HEADER} \
+  ${ISSUE_URL}/assignees \
+  -d '{"assignees":["'${PR_AUTHOR}'"]}' \
+  &> /dev/null

--- a/Bitrise/Scripts/pr_labels_testing.sh
+++ b/Bitrise/Scripts/pr_labels_testing.sh
@@ -1,20 +1,5 @@
-# We can have both HTTPS and SSH urls.
-# HTTPS: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
-# SSH: git@github.com:WeTransfer/Mule.git
-#
-# Given the difference in URLs, the shared component is the last one (e.g. Mule.git).
-# It's first needed to reverse the URL, split it by `.` and get the second part of it (the -f2 in `cut`),
-# enabling to equate the URL split:
-#   - URL: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
-#   - Reversed: tig.IC-SOi-refsnarTeW/refsnarTeW/moc.buhtig//:sptth
-#   - Sectioned: [1: tig].[2: IC-SOi-refsnarTeW/refsnarTeW/moc].[3: buhtig//:sptth]
-# The previous split is the input to the next one, this time by `/`, and then the first element is used (the -f1 in `cut`).
-#   - Input: IC-SOi-refsnarTeW/refsnarTeW/moc
-#   - Sectioned: [1: IC-SOi-refsnarTeW]/[2: refsnarTeW]/[3: moc]
-# And lastly, we revert the result one more time, as the result will be reversed otherwise.
-REPOSITORY_NAME=$(echo ${GIT_REPOSITORY_URL} | rev | cut -d '.' -f2 | cut -d '/' -f1 | rev)
-ISSUE_URL="https://api.github.com/repos/${BITRISEIO_GIT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${BITRISE_PULL_REQUEST}"
-HEADER="Accept: application/vnd.github.v3+json"
+app="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source $app/setup_environment.sh
 
 PR_LABELS=$(
   curl \

--- a/Bitrise/Scripts/pr_labels_testing.sh
+++ b/Bitrise/Scripts/pr_labels_testing.sh
@@ -1,0 +1,36 @@
+# We can have both HTTPS and SSH urls.
+# HTTPS: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
+# SSH: git@github.com:WeTransfer/Mule.git
+#
+# Given the difference in URLs, the shared component is the last one (e.g. Mule.git).
+# It's first needed to reverse the URL, split it by `.` and get the second part of it (the -f2 in `cut`),
+# enabling to equate the URL split:
+#   - URL: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
+#   - Reversed: tig.IC-SOi-refsnarTeW/refsnarTeW/moc.buhtig//:sptth
+#   - Sectioned: [1: tig].[2: IC-SOi-refsnarTeW/refsnarTeW/moc].[3: buhtig//:sptth]
+# The previous split is the input to the next one, this time by `/`, and then the first element is used (the -f1 in `cut`).
+#   - Input: IC-SOi-refsnarTeW/refsnarTeW/moc
+#   - Sectioned: [1: IC-SOi-refsnarTeW]/[2: refsnarTeW]/[3: moc]
+# And lastly, we revert the result one more time, as the result will be reversed otherwise.
+REPOSITORY_NAME=$(echo ${GIT_REPOSITORY_URL} | rev | cut -d '.' -f2 | cut -d '/' -f1 | rev)
+ISSUE_URL="https://api.github.com/repos/${BITRISEIO_GIT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${BITRISE_PULL_REQUEST}"
+HEADER="Accept: application/vnd.github.v3+json"
+
+PR_LABELS=$(
+  curl \
+    -s \
+    -u ${GITBUDDY_ACCESS_TOKEN} \
+    -H ${HEADER} \
+    ${ISSUE_URL} \
+    | jq -r '.labels[] | .name'
+)
+
+echo "PR labels are: ${PR_LABELS}"
+
+if [[ "$PR_LABELS" == *"ci-testing"* ]]; then
+  echo "This PR is configured for testing CI."
+  envman add --key CI_TESTING --value "true"
+else
+  echo "This PR is not configured for testing CI and runs as normal."
+  envman add --key CI_TESTING --value "false"
+fi

--- a/Bitrise/Scripts/setup_environment.sh
+++ b/Bitrise/Scripts/setup_environment.sh
@@ -1,0 +1,17 @@
+# We can have both HTTPS and SSH urls.
+# HTTPS: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
+# SSH: git@github.com:WeTransfer/Mule.git
+#
+# Given the difference in URLs, the shared component is the last one (e.g. Mule.git).
+# It's first needed to reverse the URL, split it by `.` and get the second part of it (the -f2 in `cut`),
+# enabling to equate the URL split:
+#   - URL: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
+#   - Reversed: tig.IC-SOi-refsnarTeW/refsnarTeW/moc.buhtig//:sptth
+#   - Sectioned: [1: tig].[2: IC-SOi-refsnarTeW/refsnarTeW/moc].[3: buhtig//:sptth]
+# The previous split is the input to the next one, this time by `/`, and then the first element is used (the -f1 in `cut`).
+#   - Input: IC-SOi-refsnarTeW/refsnarTeW/moc
+#   - Sectioned: [1: IC-SOi-refsnarTeW]/[2: refsnarTeW]/[3: moc]
+# And lastly, we revert the result one more time, as the result will be reversed otherwise.
+REPOSITORY_NAME=$(echo ${GIT_REPOSITORY_URL} | rev | cut -d '.' -f2 | cut -d '/' -f1 | rev)
+ISSUE_URL="https://api.github.com/repos/${BITRISEIO_GIT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${BITRISE_PULL_REQUEST}"
+HEADER="Accept: application/vnd.github.v3+json"

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -22,7 +22,7 @@ workflows:
 
             # Configure CI_TESTING environment variable.
             ./Bitrise/Scripts/pr_labels_testing.sh
-    - script@1:
+    - script:
         run_if: '{{enveq "CI_TESTING" "false"}}'
         title: Skip running for Draft PRs
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -90,7 +90,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -9,63 +9,21 @@ workflows:
   wetransfer_pr_testing:
     steps:
     - script:
-        title: Assign PR author
+        title: Assign PR author and configure CI Testing mode
         inputs:
         - content: |-
             #!/bin/bash
 
-            # We can have both HTTPS and SSH urls.
-            # HTTPS: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
-            # SSH: git@github.com:WeTransfer/Mule.git
-            #
-            # Given the difference in URLs, the shared component is the last one (e.g. Mule.git).
-            # It's first needed to reverse the URL, split it by `.` and get the second part of it (the -f2 in `cut`),
-            # enabling to equate the URL split:
-            #   - URL: https://github.com/WeTransfer/WeTransfer-iOS-CI.git
-            #   - Reversed: tig.IC-SOi-refsnarTeW/refsnarTeW/moc.buhtig//:sptth
-            #   - Sectioned: [1: tig].[2: IC-SOi-refsnarTeW/refsnarTeW/moc].[3: buhtig//:sptth]
-            # The previous split is the input to the next one, this time by `/`, and then the first element is used (the -f1 in `cut`).
-            #   - Input: IC-SOi-refsnarTeW/refsnarTeW/moc
-            #   - Sectioned: [1: IC-SOi-refsnarTeW]/[2: refsnarTeW]/[3: moc]
-            # And lastly, we revert the result one more time, as the result will be reversed otherwise.
-            REPOSITORY_NAME=$(echo ${GIT_REPOSITORY_URL} | rev | cut -d '.' -f2 | cut -d '/' -f1 | rev)
-            ISSUE_URL="https://api.github.com/repos/${BITRISEIO_GIT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${BITRISE_PULL_REQUEST}"
-            HEADER="Accept: application/vnd.github.v3+json"
+            chmod +x Scripts/pr_assignments.sh
+            chmod +x Scripts/pr_labels_testing.sh
 
-            PR_ASSIGNESS=$(
-              curl \
-                -s \
-                -u ${GITBUDDY_ACCESS_TOKEN} \
-                -H ${HEADER} \
-                ${ISSUE_URL} \
-                | jq -r '.assignees[] | .login'
-            )
+            # Assign a PR owner if not existing.
+            ./Scripts/pr_assignments.sh
 
-            if [ -z ${PR_ASSIGNESS} ]; then
-              echo "PR assignees is empty. Continuing..."
-            else
-              echo "PR assignees is not empty. Nothing to do here..."
-              exit 0
-            fi
-
-            PR_AUTHOR=$(
-              curl \
-                -s \
-                -u ${GITBUDDY_ACCESS_TOKEN} \
-                -H ${HEADER} \
-                ${ISSUE_URL} \
-                | jq -r .user.login
-            )
-
-            curl \
-              -s \
-              -u ${GITBUDDY_ACCESS_TOKEN} \
-              -X POST \
-              -H ${HEADER} \
-              ${ISSUE_URL}/assignees \
-              -d '{"assignees":["'${PR_AUTHOR}'"]}' \
-              &> /dev/null
+            # Configure CI_TESTING environment variable.
+            ./Scripts/pr_labels_testing.sh
     - script@1:
+        run_if: '{{enveq "CI_TESTING" "false"}}'
         title: Skip running for Draft PRs
         inputs:
         - content: |-
@@ -78,7 +36,7 @@ workflows:
         inputs:          
         - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
     - script:
-        run_if: .IsCI
+        run_if: '{{enveq "CI_TESTING" "false"}}'
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -90,7 +48,7 @@ workflows:
             fi
 
             # Get the latest master branch for WeTransfer-iOS-CI if the submodule exists
-            # git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
+            git submodule update --remote --no-fetch Submodules/WeTransfer-iOS-CI
         title: Update WeTransfer-iOS-CI submodule
     - script:
         run_if: .IsCI

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -18,10 +18,10 @@ workflows:
             chmod +x Scripts/pr_labels_testing.sh
 
             # Assign a PR owner if not existing.
-            ./Scripts/pr_assignments.sh
+            ./Bitrise/Scripts/pr_assignments.sh
 
             # Configure CI_TESTING environment variable.
-            ./Scripts/pr_labels_testing.sh
+            ./Bitrise/Scripts/pr_labels_testing.sh
     - script@1:
         run_if: '{{enveq "CI_TESTING" "false"}}'
         title: Skip running for Draft PRs

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -44,11 +44,6 @@ lane :test_project do |options|
       service_name: scheme
     )
 
-    # resolve_spm_packages(
-    #   source_packages_dir: source_packages_dir,
-    #   package_path: options[:package_path]
-    # ) unless options.fetch(:disable_automatic_package_resolution, false)
-
     scan(
       scheme: scheme,
       project: project_path,
@@ -81,14 +76,6 @@ lane :test_project do |options|
       UI.important("Tests failed for #{e}")
     end
   end
-end
-
-desc 'Resolves packages in a separate lane so we can monitor performance of it based on caching.'
-private_lane :resolve_spm_packages do |options|
-  source_packages_dir = options[:source_packages_dir]
-  resolve_command = "xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath #{source_packages_dir}"
-  resolve_command.prepend("cd #{ENV['PWD']}/#{options[:package_path]} && ") unless options[:package_path].nil?
-  sh(resolve_command)
 end
 
 desc 'Configures environment variables to enable Datadog CI Tests Tracing'

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -44,10 +44,10 @@ lane :test_project do |options|
       service_name: scheme
     )
 
-    resolve_spm_packages(
-      source_packages_dir: source_packages_dir,
-      package_path: options[:package_path]
-    ) unless options.fetch(:disable_automatic_package_resolution, false)
+    # resolve_spm_packages(
+    #   source_packages_dir: source_packages_dir,
+    #   package_path: options[:package_path]
+    # ) unless options.fetch(:disable_automatic_package_resolution, false)
 
     scan(
       scheme: scheme,
@@ -72,7 +72,7 @@ lane :test_project do |options|
       build_for_testing: options.fetch(:build_for_testing, nil),
       test_without_building: options.fetch(:test_without_building, nil),
       disable_package_automatic_updates: true, # Makes xcodebuild -showBuildSettings more reliable too.
-      skip_package_dependencies_resolution: true
+      skip_package_dependencies_resolution: options.fetch(:disable_automatic_package_resolution, false)
     )
   rescue StandardError => e
     if options.fetch(:raise_exception_on_failure, false)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -27,7 +27,7 @@ workflows:
     - activate-ssh-key:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone: {}
-    - script@1.1.6:
+    - script:
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -70,5 +70,5 @@ workflows:
 meta:
   bitrise.io:
     machine_type: standard
-    stack: osx-xcode-14.0.x
+    stack: osx-xcode-14.1.x
     machine_type_id: g2.4core


### PR DESCRIPTION
After we merged in this PR, we can add a `pr-testing` label to any PR which will allow to:
- Run CI as normal under draft
- Use the submodule CI reference instead of updating to latest `master` branch

This will improve our CI testing experience and makes it more clear for reviewers that a PR is work in progress. Before this, we had to open a PR as if it was ready to be reviewed, even though we might wanted to do some CI testing first.