### PR TITLE
Add timeout for fastlane test

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -61,6 +61,7 @@ workflows:
             # git config --global url."git@github.com:".insteadOf "https://github.com/"
             for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
     - script:
+        timeout: 2400
         title: Run Fastlane
         inputs:
         - content: |-

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -58,7 +58,7 @@ lane :test_project do |options|
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: true,
-      xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 -test-timeouts-enabled",
+      xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 -test-timeouts-enabled -maximum-test-execution-time-allowance 60",
       include_simulator_logs: false, # Needed for this: https://github.com/fastlane/fastlane/issues/8909
       result_bundle: true,
       output_directory: "#{ENV['PWD']}/build/reports/",

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -58,7 +58,7 @@ lane :test_project do |options|
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: true,
-      xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3",
+      xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 -test-timeouts-enabled",
       include_simulator_logs: false, # Needed for this: https://github.com/fastlane/fastlane/issues/8909
       result_bundle: true,
       output_directory: "#{ENV['PWD']}/build/reports/",


### PR DESCRIPTION
- [x] Adds `-test-timeouts-enabled` to allow enable [XCTest timeouts](https://developer.apple.com/documentation/xctest/xctestcase/3526064-executiontimeallowance)
- [x] Configure `-maximum-test-execution-time-allowance` of 60 seconds
- [x] Adds workflow timeout for `fastlane test` workflow. This should never exceed 40 minutes right now. We've had Bitrise builds running forever since we didn't configure this timeout correctly. This is mostly a safeguard to prevent high credit usage on Bitrise

Fixes #191 
Fixes [TMOB-1600]

[TMOB-1600]: https://wetransfer.atlassian.net/browse/TMOB-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ