### PR TITLE
Disable code coverage when build for testing

### DIFF
--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -44,12 +44,19 @@ lane :test_project do |options|
       service_name: scheme
     )
 
+    code_coverage_enabled = true
+
+    if options.fetch(:build_for_testing, false) {
+      # The flag -enableCodeCoverage is only supported when testing.
+      code_coverage_enabled = nil
+    }
+
     scan(
       scheme: scheme,
       project: project_path,
       device: device,
       destination: options[:destination],
-      code_coverage: !(options.fetch(:build_for_testing, false)), # The flag -enableCodeCoverage is only supported when testing.
+      code_coverage: code_coverage_enabled,
       disable_concurrent_testing: true, # As of 27th October 2021, this seems to not be working anymore. We need `parallel-testing-enabled NO` instead.
       fail_build: false,
       skip_slack: true,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -46,10 +46,10 @@ lane :test_project do |options|
 
     code_coverage_enabled = true
 
-    if options.fetch(:build_for_testing, false) {
+    if options.fetch(:build_for_testing, false)
       # The flag -enableCodeCoverage is only supported when testing.
       code_coverage_enabled = nil
-    }
+    end
 
     scan(
       scheme: scheme,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -49,7 +49,7 @@ lane :test_project do |options|
       project: project_path,
       device: device,
       destination: options[:destination],
-      code_coverage: true,
+      code_coverage: !(options.fetch(:build_for_testing, false)), # The flag -enableCodeCoverage is only supported when testing.
       disable_concurrent_testing: true, # As of 27th October 2021, this seems to not be working anymore. We need `parallel-testing-enabled NO` instead.
       fail_build: false,
       skip_slack: true,


### PR DESCRIPTION
Fixes:

```
[14:13:54]: ▸ xcodebuild: error: The flag -enableCodeCoverage is only supported when testing.
```