### PR TITLE
Update SwiftLint to 0.50.1 to fix precommit install

### DIFF
--- a/BuildTools/Mintfile
+++ b/BuildTools/Mintfile
@@ -1,2 +1,2 @@
 nicklockwood/SwiftFormat@0.49.7
-realm/SwiftLint@0.50.0
+realm/SwiftLint@0.50.1


### PR DESCRIPTION
See related issue: https://github.com/realm/SwiftLint/issues/4559
pre-commit would fail to install SwiftLint in 0.50.0