### PR TITLE
Allow skipping SwiftLint through Danger

### DIFF
--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -161,7 +161,7 @@ public enum WeTransferPRLinter {
     ) {
         defer { print("\n") }
 
-        guard environmentVariables["disable_danger_swiftlint"] != "true" else {
+        guard environmentVariables["DISABLE_DANGER_SWIFTLINT"] != "true" else {
             return print("Skip SwiftLint linting since `disable_danger_swiftlint` environment variable was set.")
         }
 

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -44,7 +44,7 @@ public enum WeTransferPRLinter {
         }
 
         measure(taskName: "SwiftLint") {
-            swiftLint(using: danger, executor: swiftLintExecutor, configsFolderPath: swiftLintConfigsFolderPath, fileManager: fileManager)
+            swiftLint(using: danger, executor: swiftLintExecutor, configsFolderPath: swiftLintConfigsFolderPath, fileManager: fileManager, environmentVariables: environmentVariables)
         }
     }
 
@@ -156,9 +156,14 @@ public enum WeTransferPRLinter {
         using danger: DangerDSL,
         executor: SwiftLintExecuting.Type = SwiftLintExecutor.self,
         configsFolderPath: String? = nil,
-        fileManager: FileManager
+        fileManager: FileManager,
+        environmentVariables: [String: String] = [:]
     ) {
         defer { print("\n") }
+
+        guard environmentVariables["disable_danger_swiftlint"] != "true" else {
+            return print("Skip SwiftLint linting since `disable_danger_swiftlint` environment variable was set.")
+        }
 
         let configsFolderPath: String = {
             if let configsFolderPath = configsFolderPath, fileManager.fileExists(atPath: configsFolderPath, isDirectory: nil) {

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
@@ -149,7 +149,7 @@ final class WeTransferLinterTests: XCTestCase {
             executor: mockedSwiftLintExecutor,
             configsFolderPath: customPath,
             fileManager: stubbedFileManager,
-            environmentVariables: ["disable_danger_swiftlint": "true"]
+            environmentVariables: ["DISABLE_DANGER_SWIFTLINT": "true"]
         )
 
         XCTAssertTrue(mockedSwiftLintExecutor.lintedFiles.isEmpty)

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
@@ -138,6 +138,23 @@ final class WeTransferLinterTests: XCTestCase {
         XCTAssertEqual(danger.messages.first?.message, "Download <a href=\"\(url)\" target=\"_blank\">Simulator Build</a>")
     }
 
+    func testSwiftLintSkippingIfEnvVariableSet() {
+        let danger = githubWithFilesDSL(created: ["File.swift"], fileMap: [:])
+        let mockedSwiftLintExecutor = MockedSwiftLintExecutor.self
+        let stubbedFileManager = StubbedFileManager()
+        stubbedFileManager.fileExists = true
+        let customPath = "/Users/avanderlee/Projects/"
+        WeTransferPRLinter.swiftLint(
+            using: danger,
+            executor: mockedSwiftLintExecutor,
+            configsFolderPath: customPath,
+            fileManager: stubbedFileManager,
+            environmentVariables: ["disable_danger_swiftlint": "true"]
+        )
+
+        XCTAssertTrue(mockedSwiftLintExecutor.lintedFiles.isEmpty)
+    }
+
     /// It should not trigger SwiftLint if there's no files to lint.
     func testSwiftLintSkippingForNoSwiftFiles() {
         let danger = githubWithFilesDSL(created: ["Changelog.md", "RubyTests.rb"], fileMap: [:])


### PR DESCRIPTION
By configuring `disable_danger_swiftlint` environment variable to `true` we can skip SwiftLint executed through Danger. This is useful for our projects that make use of the SwiftLint build tool plugin.