### PR TITLE
Fix Datadog CI Tracing

### DIFF
--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -61,7 +61,7 @@ lane :test_project do |options|
       fail_build: false,
       skip_slack: true,
       output_types: '',
-      xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
+      # xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: true,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -91,7 +91,7 @@ desc 'To enable Datadog CI Tests Tracing for your project:'
 desc ' 1. Add the DD_API_KEY env variable as a secret to Bitrise'
 desc ' 2. Link the DatadogSDKTesting package following instructions here: https://docs.datadoghq.com/continuous_integration/setup_tests/swift/'
 lane :configure_datadog_ci_test_tracing do |options|
-  if ENV.has_value?("DD_API_KEY")
+  if ENV.include?("DD_API_KEY")
     ENV["TEST_RUNNER_DD_TEST_RUNNER"] = '1' 
     ENV["TEST_RUNNER_DD_ENV"] = 'ci' 
     ENV["TEST_RUNNER_DD_SITE"] = 'datadoghq.eu'

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -61,7 +61,7 @@ lane :test_project do |options|
       fail_build: false,
       skip_slack: true,
       output_types: '',
-      # xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
+      xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: true,
@@ -91,19 +91,23 @@ desc 'To enable Datadog CI Tests Tracing for your project:'
 desc ' 1. Add the DD_API_KEY env variable as a secret to Bitrise'
 desc ' 2. Link the DatadogSDKTesting package following instructions here: https://docs.datadoghq.com/continuous_integration/setup_tests/swift/'
 lane :configure_datadog_ci_test_tracing do |options|
-  next unless ENV.has_value?("DD_API_KEY")
-  ENV["TEST_RUNNER_DD_TEST_RUNNER"] = '1' 
-  ENV["TEST_RUNNER_DD_ENV"] = 'ci' 
-  ENV["TEST_RUNNER_DD_SITE"] = 'datadoghq.eu'
-  ENV["TEST_RUNNER_DD_SERVICE"] = options[:service_name]
-  ENV["TEST_RUNNER_DD_API_KEY"] = ENV['DD_API_KEY']
-  ENV["TEST_RUNNER_SRCROOT"] = ENV['PWD']
-  ENV["TEST_RUNNER_DD_TRACE_DEBUG"] = '1'
-  ENV["TEST_RUNNER_DD_GIT_REPOSITORY_URL"] = ENV['GIT_REPOSITORY_URL']
-  ENV["TEST_RUNNER_DD_GIT_BRANCH"] = ENV['BITRISE_GIT_BRANCH']
-  ENV["TEST_RUNNER_DD_GIT_COMMIT_SHA"] = ENV['BITRISE_GIT_COMMIT']
-  ENV["TEST_RUNNER_DD_GIT_COMMIT_MESSAGE"] = ENV['BITRISE_GIT_MESSAGE']
-  ENV["TEST_RUNNER_DD_GIT_COMMIT_AUTHOR_NAME"] = ENV['GIT_CLONE_COMMIT_AUTHOR_NAME']
+  if ENV.has_value?("DD_API_KEY")
+    ENV["TEST_RUNNER_DD_TEST_RUNNER"] = '1' 
+    ENV["TEST_RUNNER_DD_ENV"] = 'ci' 
+    ENV["TEST_RUNNER_DD_SITE"] = 'datadoghq.eu'
+    ENV["TEST_RUNNER_DD_SERVICE"] = options[:service_name]
+    ENV["TEST_RUNNER_DD_API_KEY"] = ENV['DD_API_KEY']
+    ENV["TEST_RUNNER_SRCROOT"] = ENV['PWD']
+    ENV["TEST_RUNNER_DD_TRACE_DEBUG"] = '1'
+    ENV["TEST_RUNNER_DD_GIT_REPOSITORY_URL"] = ENV['GIT_REPOSITORY_URL']
+    ENV["TEST_RUNNER_DD_GIT_BRANCH"] = ENV['BITRISE_GIT_BRANCH']
+    ENV["TEST_RUNNER_DD_GIT_COMMIT_SHA"] = ENV['BITRISE_GIT_COMMIT']
+    ENV["TEST_RUNNER_DD_GIT_COMMIT_MESSAGE"] = ENV['BITRISE_GIT_MESSAGE']
+    ENV["TEST_RUNNER_DD_GIT_COMMIT_AUTHOR_NAME"] = ENV['GIT_CLONE_COMMIT_AUTHOR_NAME']
+    puts "Configured Datadog CI tracing."
+  else 
+    puts "Datadog CI tracing not configured since DD_API_KEY is missing."
+  end
 end
 
 desc 'Create a release from a tag triggered CI run'


### PR DESCRIPTION
Turns out we needed a different Ruby syntax 🙈 

```diff
- ENV.has_value?("DD_API_KEY")
+ ENV.include?("DD_API_KEY")
```

Learning Ruby every day!