### PR TITLE
Add macOS Support to Fastlane Match

### DIFF
--- a/Fastlane/provisioning_lanes.rb
+++ b/Fastlane/provisioning_lanes.rb
@@ -4,29 +4,71 @@ lane :install_match_dependencies do
 
   match_configuration(
     type: 'development',
-    readonly: true
+    readonly: true,
+    platform: 'ios'
   )
 
   match_configuration(
     type: 'appstore',
-    readonly: true
+    readonly: true,
+    platform: 'ios'
   )
+
+  if ENV.include?("MACOS_APP_IDENTIFIERS")
+    UI.message 'Installing macOS Match Dependencies'
+
+    match_configuration(
+      type: 'development',
+      readonly: true,
+      platform: 'macos',
+      app_identifier: ENV["MACOS_APP_IDENTIFIERS"]
+    )
+
+    match_configuration(
+      type: 'appstore',
+      readonly: true,
+      platform: 'macos',
+      app_identifier: ENV["MACOS_APP_IDENTIFIERS"]
+    )
+  end
 end
 
 desc 'Update the development certificates and profiles using fastlane match'
 lane :update_match_development_dependencies do
   match_configuration(
     type: 'development',
-    readonly: false
+    readonly: false,
+    platform: 'ios'
   )
+
+  if ENV.include?("MACOS_APP_IDENTIFIERS")
+    UI.message 'Updating macOS Match Development Dependencies'
+    match_configuration(
+      type: 'development',
+      readonly: false,
+      platform: 'macos',
+      app_identifier: ENV["MACOS_APP_IDENTIFIERS"]
+    )
+  end
 end
 
 desc 'Update the appstore certificates and profiles using fastlane match'
 lane :update_match_appstore_dependencies do
   match_configuration(
     type: 'appstore',
-    readonly: false
+    readonly: false,
+    platform: 'ios'
   )
+
+  if ENV.include?("MACOS_APP_IDENTIFIERS")
+    UI.message 'Updating macOS Match AppStore Dependencies'
+    match_configuration(
+      type: 'appstore',
+      readonly: false,
+      platform: 'macos',
+      app_identifier: ENV["MACOS_APP_IDENTIFIERS"]
+    )
+  end
 end
 
 desc 'A convenience method for using fastlane match'
@@ -36,7 +78,9 @@ private_lane :match_configuration do |options|
   sync_code_signing(
     type: options[:type],
     api_key: api_key,
-    readonly: options[:readonly]
+    readonly: options[:readonly],
+    platform: options[:platform],
+    app_identifier: options.fetch(:app_identifier, ENV["APP_IDENTIFIERS"])
   )
 end
 

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -67,7 +67,7 @@ lane :test_project do |options|
       xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
-      prelaunch_simulator: true,
+      prelaunch_simulator: false,
       xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3",
       include_simulator_logs: false, # Needed for this: https://github.com/fastlane/fastlane/issues/8909
       result_bundle: true,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -30,8 +30,10 @@ lane :test_project do |options|
   ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '30'
 
   begin
-    device = options[:device] || 'iPhone 14'
-
+    if options[:destination].nil?
+      device = options[:device] || 'iPhone 14'
+    end
+    
     if options[:package_path].nil?
       project_path = "#{options[:project_path]}#{options[:project_name]}.xcodeproj"
     end
@@ -50,6 +52,7 @@ lane :test_project do |options|
       # The flag -enableCodeCoverage is only supported when testing.
       code_coverage_enabled = nil
     end
+
 
     scan(
       scheme: scheme,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -22,9 +22,6 @@ desc ' * **`project_path`**: The path to the project'
 desc ' * **`project_name`**: The name of the project'
 desc ' * **`destination`**: ..'
 lane :test_project do |options|
-  # Remove any leftover reports before running so local runs won't fail due to an existing file.
-  sh("rm -rf #{ENV['PWD']}/build/reports") unless is_running_on_CI(options)
-
   # Set timeout to prevent xcodebuild -list -project to take to much retries.
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '30'
   ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '30'
@@ -46,13 +43,15 @@ lane :test_project do |options|
       service_name: scheme
     )
 
+    # Remove any leftover reports before running so local runs won't fail due to an existing file.
+    sh("rm -rf #{ENV['PWD']}/build/reports/#{scheme}.xcresult")
+
     code_coverage_enabled = true
 
     if options.fetch(:build_for_testing, false)
       # The flag -enableCodeCoverage is only supported when testing.
       code_coverage_enabled = nil
     end
-
 
     scan(
       step_name: options[:step_name] || "Scan - #{scheme}",

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -64,7 +64,7 @@ lane :test_project do |options|
       fail_build: false,
       skip_slack: true,
       output_types: '',
-      xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
+      # xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: false,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -28,7 +28,7 @@ lane :test_project do |options|
 
   begin
     if options[:destination].nil?
-      device = options[:device] || 'iPhone 14'
+      device = options[:device] || 'iPhone 14 (16.2)'
     end
 
     if options[:package_path].nil?

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -33,7 +33,7 @@ lane :test_project do |options|
     if options[:destination].nil?
       device = options[:device] || 'iPhone 14'
     end
-    
+
     if options[:package_path].nil?
       project_path = "#{options[:project_path]}#{options[:project_name]}.xcodeproj"
     end
@@ -55,6 +55,7 @@ lane :test_project do |options|
 
 
     scan(
+      step_name: options[:step_name] || "Scan - #{scheme}",
       scheme: scheme,
       project: project_path,
       device: device,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -39,9 +39,9 @@ lane :test_project do |options|
     source_packages_dir = "#{ENV['PWD']}/.spm-build"
     
     # Setup Datadog CI Insights
-    configure_datadog_ci_test_tracing(
-      service_name: scheme
-    )
+    # configure_datadog_ci_test_tracing(
+    #   service_name: scheme
+    # )
 
     # Remove any leftover reports before running so local runs won't fail due to an existing file.
     sh("rm -rf #{ENV['PWD']}/build/reports/#{scheme}.xcresult")

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -64,7 +64,7 @@ lane :test_project do |options|
       fail_build: false,
       skip_slack: true,
       output_types: '',
-      # xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
+      xcodebuild_formatter: '', # Add this to get verbose logging by disabling xcbeautify.
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: true,

--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -28,7 +28,7 @@ lane :test_project do |options|
 
   begin
     if options[:destination].nil?
-      device = options[:device] || 'iPhone 14 (16.2)'
+      device = options[:device] || 'iPhone 14'
     end
 
     if options[:package_path].nil?


### PR DESCRIPTION
Our provisioning lanes now support signing macOS apps as well. We've had to reuse the same lanes but with a specific platform set to `macos`. A new environment variable allows configuring `macos` platform specific bundle identifiers.