### PR TITLE
Make certs lane public

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -411,7 +411,7 @@ desc ''
 desc '#### Options'
 desc ' * **`app_identifier`**: a list of all app identifiers for which to sync the certs'
 desc ''
-private_lane :certs do |options|
+lane :certs do |options|
   # Create Keychain to store certificates in
   create_keychain(
     name: ENV['MATCH_KEYCHAIN_NAME'],

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -427,7 +427,9 @@ lane :certs do |options|
     keychain_password: (ENV['MATCH_KEYCHAIN_PASSWORD']).to_s,
     app_identifier: options[:app_identifier],
     force: true,
-    type: options[:type] || 'appstore'
+    type: options[:type] || 'appstore',
+    platform: options.fetch(:platform, 'ios'),
+    readonly: options.fetch(:readonly, false)
   )
 end
 

--- a/Fastlane/provisioning_lanes.rb
+++ b/Fastlane/provisioning_lanes.rb
@@ -84,8 +84,13 @@ private_lane :match_configuration do |options|
   )
 end
 
+desc 'Adds a Macos device to your developer account.'
+lane :add_macos_device do
+  add_device(platform: 'mac')
+end
+
 desc 'Adds a new device to your developer account.'
-lane :add_device do
+lane :add_device do |options|
   device_name = prompt(text: 'Enter the device name: ')
   device_udid = prompt(text: 'Enter the device UDID: ')
 
@@ -96,7 +101,8 @@ lane :add_device do
 
   register_devices(
     devices: device_hash,
-    team_id: ENV['FASTLANE_TEAM_ID']
+    team_id: ENV['FASTLANE_TEAM_ID'],
+    platform: options.fetch(:platform, 'ios')
   )
 
   sign


### PR DESCRIPTION
We need the lane for setting up Xcode on CI for unit testing our Mac tests.