### PR TITLE
Unshallow git history before merging a release

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -159,6 +159,10 @@ lane :release do |options|
 
     branch_name = is_hotfix ? "hotfix/#{latest_release_tag}" : "release/#{latest_release_tag}"
 
+    # This is a temporary measure to be able to merge our release.
+    # It will be revised in https://wetransfer.atlassian.net/browse/TMOB-2510
+    sh "git fetch --unshallow"
+
     sh "git branch #{branch_name} origin/main"
     sh "git checkout #{branch_name}"
 


### PR DESCRIPTION
Related to [TMOB-2510].

This PR unshallow the git history before merging a release. This is a solution we (@neodym, @kairadiagne and me) agreed upon in our investigation.

[TMOB-2510]: https://wetransfer.atlassian.net/browse/TMOB-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ