### PR TITLE
Make target branch configurable

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -75,7 +75,7 @@ lane :beta do |options|
   # Create a new GitHub release
   last_non_candidate_tag = latest_github_release_tag
   release_title = "#{tag_name} - Beta"
-  release_output = sh("mint run --silent gitbuddy release -l #{last_non_candidate_tag} -b develop --skip-comments --json --use-pre-release --target-commitish #{branch_name} --tag-name #{tag_name} --release-title '#{release_title}'")
+  release_output = sh("mint run --silent gitbuddy release -l #{last_non_candidate_tag} -b #{branch_name} --skip-comments --json --use-pre-release --target-commitish #{branch_name} --tag-name #{tag_name} --release-title '#{release_title}'")
   release_json = JSON.parse(release_output)
 
   release_url = release_json['url']


### PR DESCRIPTION
When we do a hotfix we need to target main instead of develop. Otherwise, it can't generate the changelog.