### PR TITLE
Remove unshallow check

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -159,10 +159,6 @@ lane :release do |options|
 
     branch_name = is_hotfix ? "hotfix/#{latest_release_tag}" : "release/#{latest_release_tag}"
 
-    # This is a temporary measure to be able to merge our release.
-    # It will be revised in https://wetransfer.atlassian.net/browse/TMOB-2510
-    sh "git fetch --unshallow"
-
     sh "git branch #{branch_name} origin/main"
     sh "git checkout #{branch_name}"
 


### PR DESCRIPTION
We no longer need it; in fact:

![CleanShot 2023-02-09 at 15 54 38@2x](https://user-images.githubusercontent.com/4329185/217847569-8f75890e-98dc-4fba-ae87-d113bf122e76.jpg)

