### PR TITLE
Skip comments for releases

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -181,7 +181,7 @@ lane :release do |options|
     release_latest_tag = is_hotfix ? latest_release_tag : last_non_candidate_tag
     release_base_branch = is_hotfix ? 'main' : 'develop'
     target_commitish = branch_name
-    release_output = sh("mint run --silent gitbuddy release -l #{release_latest_tag} -b #{release_base_branch} -c '../Changelog.md' --changelogToTag #{latest_release_tag} --target-commitish #{target_commitish} --tag-name #{tag_name} --release-title '#{release_title}' --json")
+    release_output = sh("mint run --silent gitbuddy release --skip-comments -l #{release_latest_tag} -b #{release_base_branch} -c '../Changelog.md' --changelogToTag #{latest_release_tag} --target-commitish #{target_commitish} --tag-name #{tag_name} --release-title '#{release_title}' --json")
     release_json = JSON.parse(release_output)
 
     release_url = release_json['url']


### PR DESCRIPTION
The comment causes more harm than adding value. We've never really used the comments, and it's hard to prevent the API rate limit without potentially spending hours rewriting GitBuddy to allow commenting separately. 

We have been running into [secondary API rate limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#secondary-rate-limits) for the GitHub API, which is caused by rapidly running many requests in a short period. The quickest solution is to disable comments for our releases. Let's start with this and see if we start to miss the comments. If so, we can add them back and potentially spend time on a bigger solution.

Fixes [TMOB-2287]