### PR TITLE
Fix unrelated history issue

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -162,7 +162,7 @@ lane :release do |options|
     sh "git branch #{branch_name} origin/main"
     sh "git checkout #{branch_name}"
 
-    sh "git merge -X theirs #{latest_release_tag}" unless is_hotfix
+    sh "git merge -X theirs #{latest_release_tag} --allow-unrelated-histories" unless is_hotfix
 
     # Update any new submodules
     sh 'git submodule sync && git submodule update --init --recursive && git submodule update --remote --no-fetch ../Submodules/WeTransfer-iOS-CI'


### PR DESCRIPTION
Following this article: https://www.educative.io/answers/the-fatal-refusing-to-merge-unrelated-histories-git-error
I hope to fix our CI issue:

![CleanShot 2023-02-17 at 14 45 08@2x](https://user-images.githubusercontent.com/4329185/219670406-497bc0bb-abd9-41b4-9d60-c5fa48eb623d.jpg)
