### PR TITLE
Revert unrelated history argument

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -162,7 +162,7 @@ lane :release do |options|
     sh "git branch #{branch_name} origin/main"
     sh "git checkout #{branch_name}"
 
-    sh "git merge -X theirs #{latest_release_tag} --allow-unrelated-histories" unless is_hotfix
+    sh "git merge -X theirs #{latest_release_tag}" unless is_hotfix
 
     # Update any new submodules
     sh 'git submodule sync && git submodule update --init --recursive && git submodule update --remote --no-fetch ../Submodules/WeTransfer-iOS-CI'


### PR DESCRIPTION
Hopefully, we no longer need this for future releases. We added this in https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/226/files, but it caused files that we moved to return back in this PR: https://github.com/WeTransfer/Mule/pull/2504/files

Let's remove it and see how our next release will go.