### PR TITLE
Increasing test timeout

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -70,7 +70,7 @@ workflows:
             # git config --global url."git@github.com:".insteadOf "https://github.com/"
             for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
     - script:
-        timeout: 2400
+        timeout: 3600
         title: Run Fastlane
         inputs:
         - content: |-


### PR DESCRIPTION
Since we're adding more and more tests, it could be possible for our test suite to run over 40 minutes when testing the Mac, iOS, and packages. Increase timeout to 1 hour, which will be enough for regular runs, but prevents hangs to run extendedly. 