### PR TITLE
Revert "Increasing test timeout"

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -70,7 +70,7 @@ workflows:
             # git config --global url."git@github.com:".insteadOf "https://github.com/"
             for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
     - script:
-        timeout: 3600
+        timeout: 2400
         title: Run Fastlane
         inputs:
         - content: |-


### PR DESCRIPTION
Reverts WeTransfer/WeTransfer-iOS-CI#230

Let's go back to the earlier limit and find out how to speed up our suite instead.