### PR TITLE
Only create a Simulator build if the label exists

### DIFF
--- a/Bitrise/Scripts/pr_labels_testing.sh
+++ b/Bitrise/Scripts/pr_labels_testing.sh
@@ -19,3 +19,11 @@ else
   echo "This PR is not configured for testing CI and runs as normal."
   envman add --key CI_TESTING --value "false"
 fi
+
+if [[ "$PR_LABELS" == *"create-simulator-build"* ]]; then
+  echo "This PR is going to deliver a Simulator Build inside the Danger message."
+  envman add --key CREATE_SIMULATOR_BUILD --value "true"
+else
+  echo "This PR is not going to deliver a Simulator Build inside the Danger message."
+  envman add --key CREATE_SIMULATOR_BUILD --value "false"
+fi

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -79,6 +79,7 @@ workflows:
             lane=${FASTLANE_LANE:=test}
             fastlane $lane
     - deploy-to-bitrise-io@2:
+        run_if: '{{enveq "CREATE_SIMULATOR_BUILD" "true"}}'
         title: Deploy Simulator Build to Bitrise
         is_skippable: true
         inputs:


### PR DESCRIPTION
Uploading the Simulator build can take up to 30 seconds, while we barely use it. I've now made it optional, but still possible. You can let CI generate a Simulator build by adding the `create-simulator-build` label.