### PR TITLE
Re-enable Danger as its a required check

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -42,6 +42,7 @@ workflows:
                 exit 1
             fi
     - restore-cache@1:          
+        run_if: '{{enveq "SKIP_TESTS" "false"}}'
         inputs:          
         - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
     - script:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -106,9 +106,6 @@ workflows:
         - key: danger-build-cache-{{ checksum "$DANGER_CHECKSUM_PATH" }}
     - script:
         title: Run Danger
-        deps:
-          brew:
-          - name: swiftlint
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -70,7 +70,7 @@ workflows:
             # git config --global url."git@github.com:".insteadOf "https://github.com/"
             for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
     - script:
-        run_if: '{{enveq "SKIP_TESTS_AND_DANGER" "false"}}'
+        run_if: '{{enveq "SKIP_TESTS" "false"}}'
         timeout: 2400
         title: Run Fastlane
         inputs:
@@ -90,7 +90,6 @@ workflows:
         - debug_mode: 'true'
         - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_TARGET}.app/  
     - script:
-        run_if: '{{enveq "SKIP_TESTS_AND_DANGER" "false"}}'
         title: Set up Danger Caching
         inputs:
         - content: |-
@@ -102,11 +101,9 @@ workflows:
                 envman add --key DANGER_BUILD_DIRECTORY --value "Submodules/WeTransfer-iOS-CI/.build"
             fi
     - restore-cache@1:      
-        run_if: '{{enveq "SKIP_TESTS_AND_DANGER" "false"}}'    
         inputs:          
         - key: danger-build-cache-{{ checksum "$DANGER_CHECKSUM_PATH" }}
     - script:
-        run_if: '{{enveq "SKIP_TESTS_AND_DANGER" "false"}}'
         title: Run Danger
         deps:
           brew:
@@ -132,7 +129,6 @@ workflows:
                 ./danger-swift ci --cwd ../../
             fi
     - save-cache@1:
-        run_if: '{{enveq "SKIP_TESTS_AND_DANGER" "false"}}'
         inputs:
         - key: danger-build-cache-{{ checksum "$DANGER_CHECKSUM_PATH" }}
         - paths: "$DANGER_BUILD_DIRECTORY"

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -14,7 +14,7 @@ public enum WeTransferPRLinter {
         fileManager: FileManager = .default,
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        let skippedTests = environmentVariables["SKIP_TESTS"] == "true"
+        let skippedTests = environmentVariables["SKIP_TESTS"]?.lowercased() == "true"
 
         measure(taskName: "XCResults Summary", skipIf: skippedTests, danger: danger) {
             reportXCResultsSummary(

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -14,7 +14,9 @@ public enum WeTransferPRLinter {
         fileManager: FileManager = .default,
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        measure(taskName: "XCResults Summary") {
+        let skippedTests = environmentVariables["SKIP_TESTS"] == "true"
+
+        measure(taskName: "XCResults Summary", skipIf: skippedTests, danger: danger) {
             reportXCResultsSummary(
                 using: danger,
                 summaryReporter: xcResultSummaryReporter,
@@ -23,32 +25,42 @@ public enum WeTransferPRLinter {
             )
         }
 
-        measure(taskName: "PR Description Validation") {
+        measure(taskName: "PR Description Validation", danger: danger) {
             validatePRDescription(using: danger)
         }
 
-        measure(taskName: "Validating Work in Progress") {
+        measure(taskName: "Validating Work in Progress", danger: danger) {
             validateWorkInProgress(using: danger)
         }
 
-        measure(taskName: "Validating Files") {
+        measure(taskName: "Validating Files", danger: danger) {
             validateFiles(using: danger)
         }
 
-        measure(taskName: "Bitrise URL showing") {
+        measure(taskName: "Bitrise URL showing", danger: danger) {
             showBitriseBuildURL(using: danger, environmentVariables: environmentVariables)
         }
 
-        measure(taskName: "Simulator Download URL showing") {
+        measure(taskName: "Simulator Download URL showing", danger: danger) {
             showSimulatorBuildDownloadURL(using: danger, environmentVariables: environmentVariables)
         }
 
-        measure(taskName: "SwiftLint") {
+        measure(taskName: "SwiftLint", skipIf: skippedTests, danger: danger) {
             swiftLint(using: danger, executor: swiftLintExecutor, configsFolderPath: swiftLintConfigsFolderPath, fileManager: fileManager, environmentVariables: environmentVariables)
         }
     }
 
-    private static func measure(taskName: String, task: () -> Void) {
+    private static func measure(
+        taskName: String,
+        skipIf shouldSkip: Bool = false,
+        danger: DangerDSL,
+        task: () -> Void
+    ) {
+        guard !shouldSkip else {
+            danger.message("Skipped running \(taskName) as `shouldSkip` returned true.")
+            return
+        }
+
         let startDate = Date()
         task()
         let differenceInSeconds = Int(Date().timeIntervalSince(startDate))

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -15,7 +15,8 @@ public enum WeTransferPRLinter {
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
         let skippedTests = environmentVariables["SKIP_TESTS"]?.lowercased() == "true"
-
+        print("Running with environment vars: \(environmentVariables)")
+        
         measure(taskName: "XCResults Summary", skipIf: skippedTests, danger: danger) {
             reportXCResultsSummary(
                 using: danger,

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -15,8 +15,7 @@ public enum WeTransferPRLinter {
         environmentVariables: [String: String] = ProcessInfo.processInfo.environment
     ) {
         let skippedTests = environmentVariables["SKIP_TESTS"]?.lowercased() == "true"
-        print("Running with environment vars: \(environmentVariables)")
-        
+
         measure(taskName: "XCResults Summary", skipIf: skippedTests, danger: danger) {
             reportXCResultsSummary(
                 using: danger,

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
@@ -155,6 +155,24 @@ final class WeTransferLinterTests: XCTestCase {
         XCTAssertTrue(mockedSwiftLintExecutor.lintedFiles.isEmpty)
     }
 
+    func testSwiftLintSkippingIfSkipTestsEnvVariableSet() {
+        let danger = githubWithFilesDSL(created: [], fileMap: [:])
+        let mockedSwiftLintExecutor = MockedSwiftLintExecutor.self
+        let stubbedFileManager = StubbedFileManager()
+        stubbedFileManager.fileExists = true
+        let customPath = "/Users/avanderlee/Projects/"
+        WeTransferPRLinter.lint(
+            using: danger,
+            swiftLintExecutor: mockedSwiftLintExecutor,
+            reportsPath: "file://faky/url",
+            swiftLintConfigsFolderPath: customPath,
+            fileManager: stubbedFileManager,
+            environmentVariables: ["SKIP_TESTS": "true"]
+        )
+
+        XCTAssertTrue(mockedSwiftLintExecutor.lintedFiles.isEmpty)
+    }
+
     /// It should not trigger SwiftLint if there's no files to lint.
     func testSwiftLintSkippingForNoSwiftFiles() {
         let danger = githubWithFilesDSL(created: ["Changelog.md", "RubyTests.rb"], fileMap: [:])


### PR DESCRIPTION
Danger is and should be a required check on our repositories. However, we can still optimize by skipping steps related to tests based on our configured environment variable.

Secondly, we can benefit from Danger running by posting a message informing us there are no expectations in terms of test results. This makes it clearer Bitrise actually skipped danger with sound reasoning, not because of a build failure.