### PR TITLE
Update env key to SKIP_TESTS

### DIFF
--- a/Bitrise/Scripts/configure_environment_for_pr.sh
+++ b/Bitrise/Scripts/configure_environment_for_pr.sh
@@ -34,8 +34,8 @@ CHANGED_FILES=$(
 
 if echo "$CHANGED_FILES" | grep -q "\.swift$"; then
   echo "The PR contains '.swift' files, let's test and run Danger"
-  envman add --key SKIP_TESTS_AND_DANGER --value "false"
+  envman add --key SKIP_TESTS --value "false"
 else
   echo "The PR does not contain '.swift' files, let's skip tests and Danger"
-  envman add --key SKIP_TESTS_AND_DANGER --value "true"
+  envman add --key SKIP_TESTS --value "true"
 fi


### PR DESCRIPTION
Somehow this change didn't made it in https://github.com/WeTransfer/WeTransfer-iOS-CI/pull/234. Needed to ensure we run tests if swift files are found.