### PR TITLE
Allow passing in parallel testing option

### DIFF
--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -68,7 +68,8 @@ lane :test_project do |options|
       suppress_xcode_output: false,
       buildlog_path: ENV['BITRISE_DEPLOY_DIR'], # By configuring `BITRISE_DEPLOY_DIR` we make sure our build log is deployed and available in Bitrise.
       prelaunch_simulator: false,
-      xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 #{options.fetch(:xcargs, nil)}",
+      parallel_testing: options.fetch(:parallel_testing, false),
+      xcargs: "-clonedSourcePackagesDirPath #{source_packages_dir} -retry-tests-on-failure -test-iterations 3 #{options.fetch(:xcargs, nil)}",
       include_simulator_logs: false, # Needed for this: https://github.com/fastlane/fastlane/issues/8909
       result_bundle: true,
       output_directory: "#{ENV['PWD']}/build/reports/",


### PR DESCRIPTION
Enabling parallel testing on CI for faster results