### PR TITLE
[Danger] Report slow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Following is a list of features which are posted in a comment on PRs based on th
   - Show code coverage of PR related files
   - Show any failed tests
   - Show all `warnings` and `errors` in the project
+  - Show slowest tests
 
 All this is written in Swift and fully tested 🚀
 
@@ -36,6 +37,11 @@ These warnings are posted inline inside the PR, helping you to solve them easily
 
 ![](Assets/danger_comment.png)
 _This is an example comment. Note that `WeTransferBot` will be replaced by your own bot. More info can be found here: [Getting started with Danger](http://danger.systems/guides/getting_started.html)._
+
+### Adjusting slowests tests
+The following environment variables can be used to adjust the slowest tests outcomes:
+- Use `SLOW_TESTS_DURATION_THRESHOLD` to configure a minimum duration threshold before a slow test shows up. Defaults to `2`.
+- Use `SLOW_TESTS_LIMIT` to configure the limit of slow tests to be shown. Defaults to `3`.
 
 # How to integrate?
 

--- a/WeTransferPRLinter/Package.swift
+++ b/WeTransferPRLinter/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "WeTransferPRLinter",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v10_15)
     ],
     products: [
         .library(
@@ -17,16 +17,16 @@ let package = Package(
     dependencies: [
         // Local package is required for development since Danger does not support Swift 5.5 correctly yet with Danger-Plugin testing.
 //         .package(name: "danger-swift", path: "../../../../../Forks/swift"),
-        .package(url: "https://github.com/danger/swift.git", from: "3.12.1"),
+               .package(name: "danger-swift", url: "https://github.com/danger/swift.git", from: "3.12.1"),
 //        .package(name: "danger-swift", url: "https://github.com/AvdLee/swift.git", .branch("master")),
-        .package(url: "https://github.com/JohnSundell/Files", from: "4.1.1"),
-        .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "0.9.2")
+               .package(name: "Files", url: "https://github.com/JohnSundell/Files", from: "4.1.1"),
+               .package(name: "XCResultKit", url: "https://github.com/davidahouse/XCResultKit.git", from: "0.9.2")
     ],
     targets: [
         .target(
             name: "WeTransferPRLinter",
             dependencies: [
-                .product(name: "Danger", package: "swift"),
+                .product(name: "Danger", package: "danger-swift"),
                 "Files",
                 "XCResultKit"
             ]
@@ -35,7 +35,7 @@ let package = Package(
             name: "WeTransferPRLinterTests",
             dependencies: [
                 "WeTransferPRLinter",
-                .product(name: "DangerFixtures", package: "swift")
+                .product(name: "DangerFixtures", package: "danger-swift")
             ],
             resources: [
                 .copy("Resources/")

--- a/WeTransferPRLinter/Package.swift
+++ b/WeTransferPRLinter/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "WeTransferPRLinter",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v12)
     ],
     products: [
         .library(
@@ -17,16 +17,16 @@ let package = Package(
     dependencies: [
         // Local package is required for development since Danger does not support Swift 5.5 correctly yet with Danger-Plugin testing.
 //         .package(name: "danger-swift", path: "../../../../../Forks/swift"),
-        .package(name: "danger-swift", url: "https://github.com/danger/swift.git", from: "3.12.1"),
+        .package(url: "https://github.com/danger/swift.git", from: "3.12.1"),
 //        .package(name: "danger-swift", url: "https://github.com/AvdLee/swift.git", .branch("master")),
-        .package(name: "Files", url: "https://github.com/JohnSundell/Files", from: "4.1.1"),
-        .package(name: "XCResultKit", url: "https://github.com/davidahouse/XCResultKit.git", from: "0.9.2")
+        .package(url: "https://github.com/JohnSundell/Files", from: "4.1.1"),
+        .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "0.9.2")
     ],
     targets: [
         .target(
             name: "WeTransferPRLinter",
             dependencies: [
-                .product(name: "Danger", package: "danger-swift"),
+                .product(name: "Danger", package: "swift"),
                 "Files",
                 "XCResultKit"
             ]
@@ -35,7 +35,7 @@ let package = Package(
             name: "WeTransferPRLinterTests",
             dependencies: [
                 "WeTransferPRLinter",
-                .product(name: "DangerFixtures", package: "danger-swift")
+                .product(name: "DangerFixtures", package: "swift")
             ],
             resources: [
                 .copy("Resources/")

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/TestSummaries.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/TestSummaries.swift
@@ -27,7 +27,10 @@ extension ActionRecord: XCResultItemsConvertible {
             }
         }
 
-        let slowestTestsItems = testPlanRunSummaries.createResultForSlowestTests()
+        var slowestTestsItems: [XCResultItem] = []
+        if #available(macOS 12.0, *) {
+            slowestTestsItems = testPlanRunSummaries.createResultForSlowestTests()
+        }
         return issueResultItems + testPlanResultItems + slowestTestsItems
     }
 }
@@ -52,6 +55,7 @@ extension ActionTestPlanRunSummaries {
         summaries.flatMap { $0.testableSummaries.flatMap(\.allTests) }
     }
 
+    @available(macOS 12.0, *)
     func createResultForSlowestTests() -> [XCResultItem] {
         let allTests = self.allTests
         guard !allTests.isEmpty else { return [] }

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/TestSummaries.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/TestSummaries.swift
@@ -58,6 +58,11 @@ extension ActionTestPlanRunSummaries {
 
         let slowestTests = allTests
             .sorted(using: KeyPathComparator(\.duration, order: .reverse))
+            .filter { test in
+                guard let duration = test.duration else { return false }
+                /// Tests under 1 second are acceptable.
+                return duration > 1
+            }
             .prefix(3)
 
         return slowestTests.compactMap { testMetadata in

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/TestSummaries.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/XCResultReporting/ResultItems/TestSummaries.swift
@@ -63,7 +63,7 @@ extension ActionTestPlanRunSummaries {
         return slowestTests.compactMap { testMetadata in
             guard let duration = testMetadata.duration else { return nil }
             let durationString = String(format: "%.3fs", duration)
-            return XCResultItem(message: "Slowest test: \(testMetadata.name) (\(durationString))", category: .message)
+            return XCResultItem(message: "Slowest test: \(testMetadata.identifier) (\(durationString))", category: .message)
         }
     }
 }

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
@@ -84,10 +84,8 @@ final class XCResultSummartReporterTests: XCTestCase {
             environmentVariables: [:]
         )
 
-        XCTAssertEqual(danger.messages.map(\.message).suffix(3), [
-            "Slowest test: TestUITests/testExample() (16.052s)",
-            "Slowest test: TestTests/testPerformanceExample() (0.266s)",
-            "Slowest test: TestThisDude/testPerformanceExample() (0.253s)"
+        XCTAssertEqual(danger.messages.map(\.message).filter { $0.contains("Slowest test") }, [
+            "Slowest test: TestUITests/testExample() (16.052s)"
         ])
     }
 

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
@@ -85,9 +85,9 @@ final class XCResultSummartReporterTests: XCTestCase {
         )
 
         XCTAssertEqual(danger.messages.map(\.message).suffix(3), [
-            "Slowest test: testExample() (16.052s)",
-            "Slowest test: testPerformanceExample() (0.266s)",
-            "Slowest test: testPerformanceExample() (0.253s)"
+            "Slowest test: TestUITests/testExample() (16.052s)",
+            "Slowest test: TestTests/testPerformanceExample() (0.266s)",
+            "Slowest test: TestThisDude/testPerformanceExample() (0.253s)"
         ])
     }
 

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
@@ -40,7 +40,7 @@ final class XCResultSummartReporterTests: XCTestCase {
             environmentVariables: [:]
         )
 
-        XCTAssertEqual(danger.messages.map(\.message), [
+        XCTAssertEqual(danger.messages.map(\.message).prefix(2), [
             "TestUITests: Executed 1 tests (0 failed, 0 retried, 0 skipped) in 16.058 seconds",
             "TestThisDude: Executed 6 tests (2 failed, 0 retried, 0 skipped) in 0.534 seconds"
         ])
@@ -66,6 +66,31 @@ final class XCResultSummartReporterTests: XCTestCase {
         }
     }
 
+    func testSlowestTestsReporting() throws {
+        let xcResultFilename = "Trainer_example_result.xcresult"
+        let xcResultFile = Bundle.module.url(forResource: "Resources/\(xcResultFilename)", withExtension: nil)!
+        let file = try Folder(path: xcResultFile.deletingLastPathComponent().path).subfolder(named: xcResultFilename)
+        try file.copy(to: buildFolder)
+
+        let danger = githubWithFilesDSL()
+        let stubbedFileManager = StubbedFileManager()
+        stubbedFileManager.stubbedCurrentDirectoryPath = "/Users/josh/Projects/fastlane/"
+
+        WeTransferPRLinter.lint(
+            using: danger,
+            swiftLintExecutor: MockedSwiftLintExecutor.self,
+            reportsPath: buildFolder.path,
+            fileManager: stubbedFileManager,
+            environmentVariables: [:]
+        )
+
+        XCTAssertEqual(danger.messages.map(\.message).suffix(3), [
+            "Slowest test: testExample() (16.052s)",
+            "Slowest test: testPerformanceExample() (0.266s)",
+            "Slowest test: testPerformanceExample() (0.253s)"
+        ])
+    }
+
     func testNotReportingRetriedSucceedingTest() throws {
         let xcResultFilename = "coverage_fail_flaky_skip_example.xcresult"
         let xcResultFile = Bundle.module.url(forResource: "Resources/\(xcResultFilename)", withExtension: nil)!
@@ -85,7 +110,7 @@ final class XCResultSummartReporterTests: XCTestCase {
             environmentVariables: [:]
         )
 
-        XCTAssertEqual(danger.messages.map(\.message), [
+        XCTAssertEqual(danger.messages.map(\.message).prefix(1), [
             "PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds"
         ], "It should only report the actual failed test, instead of also the retried succeeded one")
 
@@ -121,7 +146,7 @@ final class XCResultSummartReporterTests: XCTestCase {
             environmentVariables: [:]
         )
 
-        XCTAssertEqual(danger.messages.map(\.message), [
+        XCTAssertEqual(danger.messages.map(\.message).prefix(1), [
             "TransferTests: Executed 519 tests (0 failed, 0 retried, 0 skipped) in 39.226 seconds"
         ], "It should only report the actual failed test, instead of also the retried succeeded one")
 
@@ -153,7 +178,7 @@ final class XCResultSummartReporterTests: XCTestCase {
             environmentVariables: [:]
         )
 
-        XCTAssertEqual(danger.messages.map(\.message), [
+        XCTAssertEqual(danger.messages.map(\.message).filter { $0.contains("Executed") }, [
             "PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds",
             "PRLinterAppTests: Executed 10 tests (1 failed, 1 retried, 1 skipped) in 0.097 seconds"
         ], "Both reports should be handled")


### PR DESCRIPTION
Adds a new Danger message sharing the top 3 slowest tests. Only tests with a duration above 1 second will be evaluated. 