### PR TITLE
Bitrise Pipeline support & Local Running improvements

### DIFF
--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -104,7 +104,7 @@ workflows:
         title: Deploy pipeline test reports
         inputs:
         - pipeline_intermediate_files: |-
-            build/reports/:BITRISE_TEST_REPORTS
+            build/reports/:BITRISE_TEST_REPORTS_${FASTLANE_LANE:=DEFAULT}
     - save-cache@1:
         is_always_run: true
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -6,9 +6,7 @@ trigger_map:
 - pull_request_source_branch: "*"
   workflow: wetransfer_pr_testing
 workflows:
-  wetransfer_pr_testing:
-    after_run:
-    - workflow_danger
+  pr_testing:
     steps:
     - script:
         title: Assign PR author and configure CI Testing mode
@@ -106,6 +104,13 @@ workflows:
         - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
         - paths: .spm-build
         - is_key_unique: 'true'
+
+  wetransfer_pr_testing:
+    before_run:
+    - pr_testing
+    after_run:
+    - workflow_danger
+    
   workflow_danger:
     steps:
     - script:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -7,6 +7,8 @@ trigger_map:
   workflow: wetransfer_pr_testing
 workflows:
   wetransfer_pr_testing:
+    after_run:
+    - workflow_danger
     steps:
     - script:
         title: Assign PR author and configure CI Testing mode
@@ -46,7 +48,7 @@ workflows:
         inputs:          
         - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
     - script:
-        run_if: '{{enveq "CI_TESTING" "false"}}'
+        run_if: '{{enveq "CI_TESTING" "false" | and .IsCI }}'
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -90,6 +92,22 @@ workflows:
         - is_compress: 'true'
         - debug_mode: 'true'
         - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_TARGET}.app/  
+    - deploy-to-bitrise-io@2:
+        is_skippable: true
+        inputs:
+        - notify_user_groups: none
+        - is_enable_public_page: 'false'
+        - is_compress: 'true'
+        - debug_mode: 'true'
+        - deploy_path: build/reports/
+    - save-cache@1:
+        is_always_run: true
+        inputs:
+        - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
+        - paths: .spm-build
+        - is_key_unique: 'true'
+  workflow_danger:
+    steps:
     - script:
         title: Set up Danger Caching
         inputs:
@@ -130,18 +148,4 @@ workflows:
         inputs:
         - key: danger-build-cache-{{ checksum "$DANGER_CHECKSUM_PATH" }}
         - paths: "$DANGER_BUILD_DIRECTORY"
-        - is_key_unique: 'true'
-    - deploy-to-bitrise-io@2:
-        is_skippable: true
-        inputs:
-        - notify_user_groups: none
-        - is_enable_public_page: 'false'
-        - is_compress: 'true'
-        - debug_mode: 'true'
-        - deploy_path: build/reports/
-    - save-cache@1:
-        is_always_run: true
-        inputs:
-        - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
-        - paths: .spm-build
         - is_key_unique: 'true'

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -91,6 +91,7 @@ workflows:
         - debug_mode: 'true'
         - deploy_path: build/derived_data/Build/Products/Debug-iphonesimulator/${XCODE_TARGET}.app/  
     - deploy-to-bitrise-io@2:
+        run_if: '{{enveq "SKIP_TESTS" "false"}}'
         is_skippable: true
         inputs:
         - notify_user_groups: none
@@ -98,6 +99,8 @@ workflows:
         - is_compress: 'true'
         - debug_mode: 'true'
         - deploy_path: build/reports/
+        - pipeline_intermediate_files: |-
+            "build/reports/:BITRISE_TEST_REPORTS"
     - save-cache@1:
         is_always_run: true
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -99,6 +99,10 @@ workflows:
         - is_compress: 'true'
         - debug_mode: 'true'
         - deploy_path: build/reports/
+    - deploy-to-bitrise-io@2:
+        run_if: '{{enveq "SKIP_TESTS" "false"}}'
+        title: Deploy pipeline test reports
+        inputs:
         - pipeline_intermediate_files: |-
             build/reports/:BITRISE_TEST_REPORTS
     - save-cache@1:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -100,7 +100,7 @@ workflows:
         - debug_mode: 'true'
         - deploy_path: build/reports/
         - pipeline_intermediate_files: |-
-            "build/reports/:BITRISE_TEST_REPORTS"
+            build/reports/:BITRISE_TEST_REPORTS
     - save-cache@1:
         is_always_run: true
         inputs:

--- a/Bitrise/testing_bitrise.yml
+++ b/Bitrise/testing_bitrise.yml
@@ -42,7 +42,7 @@ workflows:
                 exit 1
             fi
     - restore-cache@1:          
-        run_if: '{{enveq "SKIP_TESTS" "false"}}'
+        run_if: '{{enveq "SKIP_TESTS" "false" | and .IsCI }}'
         inputs:          
         - key: spm-cache-{{ checksum "Package.resolved" "*.xcodeproj/**/Package.resolved" "WeTransferPRLinter/Package.resolved" }}
     - script:

--- a/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
+++ b/WeTransferPRLinter/Sources/WeTransferPRLinter/WeTransferPRLinter.swift
@@ -111,9 +111,13 @@ public enum WeTransferPRLinter {
             }
             print("Finished reporting XCResult summaries.")
         } catch let error as LocationError where error.isMissingError {
-            danger.message("No tests found for the current changes in \(reportsPath)")
+            let message = "No tests found for the current changes in \(reportsPath)"
+            print(message)
+            danger.message(message)
         } catch {
-            danger.warn("XCResult Summary failed with error: \(error).")
+            let warning = "XCResult Summary failed with error: \(error)."
+            print(warning)
+            danger.warn(warning)
         }
     }
 

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/WeTransferLinterTests.swift
@@ -219,14 +219,12 @@ final class WeTransferLinterTests: XCTestCase {
             using: danger,
             summaryReporter: XCResultSummaryReporter.self,
             reportsPath: "file://faky/url",
-            fileManager: .default
+            fileManager: .default,
+            environmentVariables: [:]
         )
 
         XCTAssertEqual(danger.warnings.count, 0)
-        XCTAssertEqual(danger.messages.count, 1)
-        XCTAssertEqual(danger.messages.map(\.message), [
-            "No tests found for the current changes in file://faky/url"
-        ])
+        XCTAssertEqual(danger.messages.count, 0)
     }
 }
 

--- a/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
+++ b/WeTransferPRLinter/Tests/WeTransferPRLinterTests/XCResultSummaryReporterTests.swift
@@ -66,6 +66,28 @@ final class XCResultSummartReporterTests: XCTestCase {
         }
     }
 
+    func testXCResultSummaryReportingFromENV() throws {
+        let xcResultFilename = "Trainer_example_result.xcresult"
+        let xcResultFile = Bundle.module.url(forResource: "Resources/\(xcResultFilename)", withExtension: nil)!
+
+        let danger = githubWithFilesDSL()
+        let stubbedFileManager = StubbedFileManager()
+        stubbedFileManager.stubbedCurrentDirectoryPath = "/Users/josh/Projects/fastlane/"
+
+        WeTransferPRLinter.lint(
+            using: danger,
+            swiftLintExecutor: MockedSwiftLintExecutor.self,
+            reportsPath: buildFolder.path,
+            fileManager: stubbedFileManager,
+            environmentVariables: ["BITRISE_TEST_REPORTS_TEST": xcResultFile.deletingLastPathComponent().path]
+        )
+
+        XCTAssertEqual(danger.messages.map(\.message).prefix(2), [
+            "TestUITests: Executed 1 tests (0 failed, 0 retried, 0 skipped) in 16.058 seconds",
+            "TestThisDude: Executed 6 tests (2 failed, 0 retried, 0 skipped) in 0.534 seconds"
+        ])
+    }
+
     func testSlowestTestsReporting() throws {
         let xcResultFilename = "Trainer_example_result.xcresult"
         let xcResultFile = Bundle.module.url(forResource: "Resources/\(xcResultFilename)", withExtension: nil)!


### PR DESCRIPTION
- [x] Split up workflow steps to run tests and danger individually
- [x] Allow reporting `xcresult` files based on environment variable input
- [x] Marked more steps as CI-only to better support running Bitrise locally
- [x] Deploying test reports for usage in build pipelines