### PR TITLE
Generate provisioning profile for multiple apps using sign lane

### DIFF
--- a/Fastlane/provisioning_lanes.rb
+++ b/Fastlane/provisioning_lanes.rb
@@ -110,7 +110,8 @@ end
 
 desc 'Download and refresh profiles for local development'
 private_lane :sign do
-  match(type: 'development', force: true)
-  match(type: 'adhoc', force: true)
-  match(type: 'appstore', force: true)
+  app_identifiers = ENV['APP_IDENTIFIERS']
+  match(type: 'development', force: true, app_identifier: app_identifiers)
+  match(type: 'adhoc', force: true, app_identifier: app_identifiers)
+  match(type: 'appstore', force: true, app_identifier: app_identifiers)
 end


### PR DESCRIPTION
After adding a device it would only generate a provisioning profile for the main app. However, we also needed to generate new profiles for the app extensions. This PR fixes that issue.