### PR TITLE
Ruby 3.2.2 broke our CI, using double asterisk we solve this

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -443,7 +443,8 @@ desc ''
 private_lane :current_preparing_app_version do |options|
   UI.message 'fetching highest version on App Store Connect...'
 
-  token = Spaceship::ConnectAPI::Token.create(Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY])
+  api_key = Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
+  token = Spaceship::ConnectAPI::Token.create(**api_key)
   Spaceship::ConnectAPI.token = token
 
   app = Spaceship::ConnectAPI::App.find(options[:app_identifier])


### PR DESCRIPTION
Don't ask me why, but the `**` needed to be added. I investigated the use of our code and compared it with Fastlane's code. I found out this was the difference.

I could reproduce the failure locally and solved it this way 🚀 