### PR TITLE
[TMOB 3481] Improve readability of changelogs

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -531,44 +531,10 @@ private_lane :latest_github_release_tag do
   latest_release['tag_name']
 end
 
-lane :markdown_url_strip_test do
-  input = "<!-- Release notes generated using configuration in .github/release.yml at release/2.0.2b6876 -->
-
-## What's Changed
-### Features and Bugfixes
-* Tracking for `accessibilityPerformEscape` for the feature discovery modal by @peagasilva in https://github.com/WeTransfer/Mule/pull/2999
-* Update marketing version to `2.0.2` by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3013
-* [TMOB 3574] fix unit tests by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3003
-* [Cellular Settings] remove toggle by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3014
-* Temporarily add fallback creative ads response locally by @peagasilva in https://github.com/WeTransfer/Mule/pull/3011
-* Add tracking for when the modal is dismissed interactively by @peagasilva in https://github.com/WeTransfer/Mule/pull/3015
-* [Cellular Settings] create settings view by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3017
-* [Send flow] Make the whole Files + > a button by @BasThomas in https://github.com/WeTransfer/Mule/pull/3009
-* [Mac App] Adjust statusbar icon for Menu Bar appearance by @AvdLee in https://github.com/WeTransfer/Mule/pull/3023
-* [Live Activity]: Adding alerts by @neodym in https://github.com/WeTransfer/Mule/pull/3024
-* Mobile Ads - Update local fallback response by @peagasilva in https://github.com/WeTransfer/Mule/pull/3025
-* Add error description copy by @AvdLee in https://github.com/WeTransfer/Mule/pull/3020
-* [TMOB-3448] - Improve handling of pending payments by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3021
-* [Cellular Settings] cellular usage picker by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3026
-### Non-testable Changes
-* Fix failing test in ContactSyncing package by @BasThomas in https://github.com/WeTransfer/Mule/pull/3005
-* Update iMessage screenshots by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3010
-* [TMOB 3418] Event tracking migration by @AvdLee in https://github.com/WeTransfer/Mule/pull/2992
-* Add unit tests for subscription tracking by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3006
-* Remove StoreKit 2 experiment by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3022
-* Add system resources to Amplitude Transfer Sent event by @AvdLee in https://github.com/WeTransfer/Mule/pull/3030
-
-
-**Full Changelog**: https://github.com/WeTransfer/Mule/compare/2.0.1b6820...2.0.2b6912"
-  
-
-  UI.message "Stripped output is: \n #{strip_changelog(input: input)}"
-end
-
-desc 'Strips Markdown URLs and returns it as plain text'
+desc 'Strips URLs and unuseful decoration for reading changelogs outside of GitHub'
 desc 'Used for example for the App Store changelog'
 desc '#### Options'
-desc ' * **`input`**: The text from which to strip the Markdown URLs'
+desc ' * **`input`**: The text from which to strip the URLs and decoration'
 desc ''
 private_lane :strip_changelog do |options|
   output = options[:input]
@@ -577,8 +543,8 @@ private_lane :strip_changelog do |options|
     # Remove all trailing URLs including the " in " prefix.
     .gsub(/ in https?:\/\/[\S]+/, '')
 
-  # Remove the last line containing "Full Changelog..." since it's not useful outside of GitHub.
-  lines = output.strip.split("\n")
+  # Remove the last line containing "Full Changelog..." since it's not useful outside of GitHub, and the first line containing <!--- Release notes...
+  lines = output.strip.split("\n").drop(1)
   lines.pop
 
   # Join together again, chop (aka trim) linebreaks and whitespaces, and return as the result.

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -80,7 +80,7 @@ lane :beta do |options|
 
   release_url = release_json['url']
   changelog = release_json['changelog']
-  stripped_changelog = strip_markdown_url(input: changelog)
+  stripped_changelog = strip_changelog(input: changelog)
   truncated_changelog = truncate(stripped_changelog, 3900) # 4000 characters is the maximum allowed by Apple
 
   UI.message "Created release with URL: #{release_url}"
@@ -188,7 +188,7 @@ lane :release do |options|
 
     release_url = release_json['url']
     changelog = release_json['changelog']
-    stripped_changelog = strip_markdown_url(input: changelog)
+    stripped_changelog = strip_changelog(input: changelog)
 
     UI.message "Created release with URL: #{release_url}"
 
@@ -531,13 +531,58 @@ private_lane :latest_github_release_tag do
   latest_release['tag_name']
 end
 
+lane :markdown_url_strip_test do
+  input = "<!-- Release notes generated using configuration in .github/release.yml at release/2.0.2b6876 -->
+
+## What's Changed
+### Features and Bugfixes
+* Tracking for `accessibilityPerformEscape` for the feature discovery modal by @peagasilva in https://github.com/WeTransfer/Mule/pull/2999
+* Update marketing version to `2.0.2` by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3013
+* [TMOB 3574] fix unit tests by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3003
+* [Cellular Settings] remove toggle by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3014
+* Temporarily add fallback creative ads response locally by @peagasilva in https://github.com/WeTransfer/Mule/pull/3011
+* Add tracking for when the modal is dismissed interactively by @peagasilva in https://github.com/WeTransfer/Mule/pull/3015
+* [Cellular Settings] create settings view by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3017
+* [Send flow] Make the whole Files + > a button by @BasThomas in https://github.com/WeTransfer/Mule/pull/3009
+* [Mac App] Adjust statusbar icon for Menu Bar appearance by @AvdLee in https://github.com/WeTransfer/Mule/pull/3023
+* [Live Activity]: Adding alerts by @neodym in https://github.com/WeTransfer/Mule/pull/3024
+* Mobile Ads - Update local fallback response by @peagasilva in https://github.com/WeTransfer/Mule/pull/3025
+* Add error description copy by @AvdLee in https://github.com/WeTransfer/Mule/pull/3020
+* [TMOB-3448] - Improve handling of pending payments by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3021
+* [Cellular Settings] cellular usage picker by @swaan-miller in https://github.com/WeTransfer/Mule/pull/3026
+### Non-testable Changes
+* Fix failing test in ContactSyncing package by @BasThomas in https://github.com/WeTransfer/Mule/pull/3005
+* Update iMessage screenshots by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3010
+* [TMOB 3418] Event tracking migration by @AvdLee in https://github.com/WeTransfer/Mule/pull/2992
+* Add unit tests for subscription tracking by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3006
+* Remove StoreKit 2 experiment by @kairadiagne in https://github.com/WeTransfer/Mule/pull/3022
+* Add system resources to Amplitude Transfer Sent event by @AvdLee in https://github.com/WeTransfer/Mule/pull/3030
+
+
+**Full Changelog**: https://github.com/WeTransfer/Mule/compare/2.0.1b6820...2.0.2b6912"
+  
+
+  UI.message "Stripped output is: \n #{strip_changelog(input: input)}"
+end
+
 desc 'Strips Markdown URLs and returns it as plain text'
 desc 'Used for example for the App Store changelog'
 desc '#### Options'
 desc ' * **`input`**: The text from which to strip the Markdown URLs'
 desc ''
-private_lane :strip_markdown_url do |options|
-  options[:input].gsub(/(?:__|[*#])|\[(.*?)\]\(.*?\)/, '\1')
+private_lane :strip_changelog do |options|
+  output = options[:input]
+    # Add an extra enter before headers
+    .gsub('### ', "\n### ")
+    # Remove all trailing URLs including the " in " prefix.
+    .gsub(/ in https?:\/\/[\S]+/, '')
+
+  # Remove the last line containing "Full Changelog..." since it's not useful outside of GitHub.
+  lines = output.strip.split("\n")
+  lines.pop
+
+  # Join together again, chop (aka trim) linebreaks and whitespaces, and return as the result.
+  lines.join("\n").chop
 end
 
 desc 'Generates a new tag name using the projects build and version number'


### PR DESCRIPTION
Before this change, we had a changelog looking as follows:

![image](https://github.com/WeTransfer/WeTransfer-iOS-CI/assets/4329185/c75bca17-a2d1-4b6b-9b59-239b275ef567)

Not super readable. We decided to improve this, resulting in the following changelog from now on:

```
## What's Changed

### Features and Bugfixes
* Tracking for `accessibilityPerformEscape` for the feature discovery modal by @peagasilva
* Update marketing version to `2.0.2` by @kairadiagne
* fix unit tests by @swaan-miller
* [Cellular Settings] remove toggle by @swaan-miller
* Temporarily add fallback creative ads response locally by @peagasilva
* Add tracking for when the modal is dismissed interactively by @peagasilva
* [Cellular Settings] create settings view by @swaan-miller
* [Send flow] Make the whole Files + > a button by @BasThomas
* [Mac App] Adjust statusbar icon for Menu Bar appearance by @AvdLee
* [Live Activity]: Adding alerts by @neodym
* Mobile Ads - Update local fallback response by @peagasilva
* Add error description copy by @AvdLee
* Improve handling of pending payments by @kairadiagne
* [Cellular Settings] cellular usage picker by @swaan-miller

### Non-testable Changes
* Fix failing test in ContactSyncing package by @BasThomas
* Update iMessage screenshots by @kairadiagne
* Event tracking migration by @AvdLee
* Add unit tests for subscription tracking by @kairadiagne
* Remove StoreKit 2 experiment by @kairadiagne
* Add system resources to Amplitude Transfer Sent event by @AvdLee
```

Fixes [TMOB-3481]

[TMOB-3481]: https://wetransfer.atlassian.net/browse/TMOB-3481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ