### PR TITLE
Update SwiftLint rules

### DIFF
--- a/BuildTools/.swiftlint.yml
+++ b/BuildTools/.swiftlint.yml
@@ -84,10 +84,10 @@ object_literal:
   color_literal: false
 type_contents_order:
   order:
-    - type_alias
     - case
     - subtype
     - associated_type
+    - type_alias
     - ib_outlet
     - ib_inspectable
     - type_property

--- a/BuildTools/.swiftlint.yml
+++ b/BuildTools/.swiftlint.yml
@@ -84,14 +84,14 @@ object_literal:
   color_literal: false
 type_contents_order:
   order:
+    - type_alias
     - case
     - subtype
     - associated_type
-    - type_alias
     - ib_outlet
     - ib_inspectable
     - type_property
-    - [initializer, instance_property]
+    - [deinitializer, initializer, instance_property]
     - view_life_cycle_method
     - [subscript, other_method, ib_action]
     - type_method


### PR DESCRIPTION
Enables https://github.com/WeTransfer/Mule/pull/3302.

This PR updates both SwiftLint rules to include `deinit` closer to `init`.

### Related Jira Issue
This PR fixes [TMOB-1798].

[TMOB-1798]: https://wetransfer.atlassian.net/browse/TMOB-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ