### PR TITLE
Make sure we don't update screenshots during our release workflow

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -278,7 +278,11 @@ lane :release do |options|
       phased_release: true,
       automatic_release: false,
       precheck_include_in_app_purchases: false,
-      skip_screenshots: true, # Screenshots should be manually updated using `fastlane deliver_screenshots`.
+
+      # Screenshots should be manually updated using `fastlane deliver_screenshots`.
+      # Updating screenshots during the release phase risks unexpected issues and could delay our
+      # release train. Therefore, we want to update screenshots explicitly to capture issues early on.
+      skip_screenshots: true, 
       submission_information: {
         add_id_info_uses_idfa: false
       }

--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -278,6 +278,7 @@ lane :release do |options|
       phased_release: true,
       automatic_release: false,
       precheck_include_in_app_purchases: false,
+      skip_screenshots: true, # Screenshots should be manually updated using `fastlane deliver_screenshots`.
       submission_information: {
         add_id_info_uses_idfa: false
       }


### PR DESCRIPTION
After we've been running into issues with our last screenshots update, I decided to revisit the flow and wrote this documentation:
https://www.notion.so/wetransfer/Update-App-Store-Metadata-Screenshots-75ec032045174dbd911623ee87565452

Part of it is that we will no longer wait for the CI release train to update screenshots and have the risk of our release train failing due to screenshot issues. Instead, we will manually update screenshots locally using `fastlane deliver_screenshots`. 
In fact, you only have to update the screenshots once, and it's a much better workflow to verify uploaded screenshots while updating.

This means that we can now skip screenshots during our CI release train.

Fixes [TMOB-4115]

[TMOB-4115]: https://wetransfer.atlassian.net/browse/TMOB-4115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ