### PR TITLE
Add a scan option for test plans

### DIFF
--- a/Fastlane/testing_lanes.rb
+++ b/Fastlane/testing_lanes.rb
@@ -58,6 +58,7 @@ lane :test_project do |options|
     scan(
       step_name: options[:step_name] || "Scan - #{scheme}",
       scheme: scheme,
+      testplan: options[:testplan],
       project: project_path,
       device: device,
       destination: options[:destination],


### PR DESCRIPTION
Allows testing using a test plan instead of a scheme.