### PR TITLE
Remove "nesting" rule from .swiftlint.yml

### DIFF
--- a/BuildTools/.swiftlint.yml
+++ b/BuildTools/.swiftlint.yml
@@ -8,6 +8,7 @@ disabled_rules: # Rule identifiers to exclude from running
   - switch_case_alignment
   - trailing_comma
   - todo
+  - nesting
 opt_in_rules:
   - block_based_kvo
   - class_delegate_protocol


### PR DESCRIPTION
### Motivation 
We quite often disable this rule in the project because it can be useful to structure our models. It felt like it's worth removing this rule since we're not respecting it everywhere.

### Mule PR
https://github.com/WeTransfer/Mule/pull/3355