### PR TITLE
Update `git diff` command

### DIFF
--- a/Fastlane/deployment_lanes.rb
+++ b/Fastlane/deployment_lanes.rb
@@ -372,7 +372,7 @@ desc 'Returns true if there are new changes since the last available tag'
 private_lane :is_changed_since_last_tag do
   sh "git fetch --tags origin #{ENV['BITRISE_GIT_BRANCH']} --no-recurse-submodules"
   last_tag = last_git_tag
-  changes = sh "git diff --name-only HEAD #{last_tag}"
+  changes = sh "git --no-pager diff --name-status #{last_tag} HEAD"
   UI.message "Is local HEAD changed since last tag #{last_tag}: #{!changes.empty?}"
   is_changed = !changes.empty?
 end


### PR DESCRIPTION
This PR updates the `git diff` command used in CI to list the changes.

The updated command uses the `--no-pager` option, to avoid Git being piped into a pager - more information [here](https://git-scm.com/docs/git/2.43.0).

<img width="249" alt="image" src="https://github.com/WeTransfer/WeTransfer-iOS-CI/assets/5387088/dc276b8d-cd7f-4a85-90c0-120766cb70b4"> <br>

It also updates the command to use the `--name-status` option, which will give us more information about the changes in the list - more information [here](https://git-scm.com/docs/git-status#_changed_tracked_entries).

Lastly, it diffs the last tag against `HEAD` instead, so it will give us the new changes.

## Preview

| Before | After |
:---: | :---:
| <img width=200 src="https://github.com/WeTransfer/WeTransfer-iOS-CI/assets/5387088/4a4a6197-bbf4-40c0-8f5a-e9e43b962afd" /> | <img width=400 src="https://github.com/WeTransfer/WeTransfer-iOS-CI/assets/5387088/4c4a50b7-00d2-4dcd-a6f8-cc4b1f2cc0d8" /> |


