### PR TITLE
Update machine type to M1

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -71,4 +71,4 @@ meta:
   bitrise.io:
     machine_type: standard
     stack: osx-xcode-14.2.x
-    machine_type_id: g2.4core
+    machine_type_id: g2-m1.4core


### PR DESCRIPTION
This PR updates the machine type to use M1 instead of Intel. [Bitrise will no longer support Intel machines](https://discuss.bitrise.io/t/macos-intel-machine-type-spring-cleaning-on-the-3rd-of-june/24043).