### PR TITLE
Exclude `ios-libs-monorepo` submodule in `.swiftformat`

### DIFF
--- a/BuildTools/.swiftformat
+++ b/BuildTools/.swiftformat
@@ -5,3 +5,4 @@
 --commas inline
 --selfrequired waitFor,expectation
 --swiftversion 5.9
+--exclude ../../ios-libs-monorepo


### PR DESCRIPTION
As per title, exclude the BSP monorepo submodule introduced by [#4313](https://github.com/WeTransfer/Mule/pull/4313) on `Mule` so that the pre-commit hook doesn't format it each time