### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'Stale'


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply chain security.

Actions referenced by tag or branch have been resolved to their commit SHA, with the original ref preserved as an inline comment. Where a sub-action had unpinned transitive dependencies, the action was upgraded to the closest newer version where all sub-actions are fully pinned.
